### PR TITLE
feat: add llms.txt support to landing

### DIFF
--- a/landing/firebase.json
+++ b/landing/firebase.json
@@ -1,5 +1,9 @@
 {
   "hosting": {
+    "predeploy": [
+      "./scripts/build-css.sh",
+      "./scripts/build-llms.sh"
+    ],
     "public": "public",
     "ignore": [
       "firebase.json",
@@ -7,6 +11,32 @@
       "**/.DS_Store"
     ],
     "headers": [
+      {
+        "source": "/llms*.txt",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "text/plain; charset=utf-8"
+          },
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=3600"
+          }
+        ]
+      },
+      {
+        "source": "**/*.md",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "text/plain; charset=utf-8"
+          },
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=3600"
+          }
+        ]
+      },
       {
         "source": "/.well-known/assetlinks.json",
         "headers": [

--- a/landing/public/about.md
+++ b/landing/public/about.md
@@ -8,31 +8,21 @@ We think your health data should actually help you. Our goal is to let AI assist
 
 We're making health insights available to everyone by connecting your fitness tracker and health apps with AI assistants like ChatGPT and Claude.
 
-__
-
 ## How It Started
 
 vytalLink started because we were frustrated with having health data stuck in different apps with no easy way to understand what it meant.
 
 We knew AI assistants like ChatGPT and Claude could give great health insights, but they needed a safe way to access our personal data. That's what vytalLink does.
 
-__
-
 ## Our Values
-
-__
 
 ### Privacy First
 
 Your health data stays on your phone. We only share it when you ask questions and want answers.
 
-__
-
 ### User Control
 
 You choose what data to share, when to share it, and which AI assistants get to see it.
-
-__
 
 ### Open Innovation
 
@@ -44,6 +34,4 @@ vytalLink is built by [Xmartlabs](https://xmartlabs.com), a software company tha
 
 We've been building digital health solutions for over ten years, so we know how important privacy, security, and ease of use are in health apps.
 
-[Learn About Xmartlabs](https://xmartlabs.com)
-
-__
+- [Learn About Xmartlabs](https://xmartlabs.com)

--- a/landing/public/about.md
+++ b/landing/public/about.md
@@ -1,0 +1,49 @@
+# About vytalLink
+
+Connecting your health data with AI assistants you already use
+
+## Our Mission
+
+We think your health data should actually help you. Our goal is to let AI assistants read your health info safely, privately, and only when you want them to.
+
+We're making health insights available to everyone by connecting your fitness tracker and health apps with AI assistants like ChatGPT and Claude.
+
+__
+
+## How It Started
+
+vytalLink started because we were frustrated with having health data stuck in different apps with no easy way to understand what it meant.
+
+We knew AI assistants like ChatGPT and Claude could give great health insights, but they needed a safe way to access our personal data. That's what vytalLink does.
+
+__
+
+## Our Values
+
+__
+
+### Privacy First
+
+Your health data stays on your phone. We only share it when you ask questions and want answers.
+
+__
+
+### User Control
+
+You choose what data to share, when to share it, and which AI assistants get to see it.
+
+__
+
+### Open Innovation
+
+We use open standards like MCP so vytalLink works with different AI platforms.
+
+## Built by Xmartlabs
+
+vytalLink is built by [Xmartlabs](https://xmartlabs.com), a software company that specializes in mobile apps, AI integration, and health tech.
+
+We've been building digital health solutions for over ten years, so we know how important privacy, security, and ease of use are in health apps.
+
+[Learn About Xmartlabs](https://xmartlabs.com)
+
+__

--- a/landing/public/app.html
+++ b/landing/public/app.html
@@ -208,7 +208,7 @@
     </style>
   <script>
     const PLAY_URL = "https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink";
-    const APP_STORE_URL = "https://apps.apple.com/us/app/vytallink/id6752308627";
+    const APP_STORE_URL = "https://apps.apple.com/app/id6752308627";
 
     const ua = navigator.userAgent || "";
     const isAndroid = /Android/i.test(ua);
@@ -238,7 +238,7 @@
         <p class="subtitle">Connect your wearable data to your AI agent.</p>
 
         <div class="store-buttons">
-          <a class="store-btn store-btn--apple" href="https://apps.apple.com/us/app/vytallink/id6752308627">
+          <a class="store-btn store-btn--apple" href="https://apps.apple.com/app/id6752308627">
             <span class="store-btn-icon">
               <svg viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
                 <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>

--- a/landing/public/chatgpt-setup.html
+++ b/landing/public/chatgpt-setup.html
@@ -259,10 +259,10 @@
                     </div>
                     <p>Connecting your health data with AI, securely and privately.</p>
                     <div class="download-footer">
-                        <a href="https://apps.apple.com/app/vytallink" target="_blank">
+                        <a href="https://apps.apple.com/app/id6752308627" target="_blank">
                             <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on App Store">
                         </a>
-                        <a href="https://play.google.com/store/apps/details?id=com.vytallink" target="_blank">
+                        <a href="https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink" target="_blank">
                             <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play">
                         </a>
                     </div>

--- a/landing/public/chatgpt-setup.md
+++ b/landing/public/chatgpt-setup.md
@@ -2,67 +2,48 @@
 
 Connect vytalLink with ChatGPT and start getting answers about your health data
 
-__ Most Popular Integration
+_Most Popular Integration_
 
 ## What is vytalLink's Custom GPT?
 
 We built a custom version of ChatGPT that knows how to read health data. It understands your fitness metrics and gives you personalized insights about your wellness in your language.
 
-__ AI that understands health and fitness data
+- AI that understands health and fitness data
+- Spots trends and patterns in your workouts
+- Gives answers in plain English
+- Safe connection to your health data
 
-__ Spots trends and patterns in your workouts
+### Example Conversation
 
-__ Gives answers in plain English
+- **You:** Show me my sleep patterns for the last week
 
-__ Safe connection to your health data
-
-__
-
-vytalLink GPT
-
-Show me my sleep patterns for the last week
-
-Based on your data, you've been averaging 7.2 hours of sleep per night this week. I notice you're going to bed consistently around 11 PM, which is great for maintaining a healthy sleep schedule! 📊
+- **Assistant:** Based on your data, you've been averaging 7.2 hours of sleep per night this week. I notice you're going to bed consistently around 11 PM, which is great for maintaining a healthy sleep schedule! 📊
 
 ## How to Set Up ChatGPT Integration
 
 Follow these steps to connect your health data with ChatGPT
 
-1
-
-### Download and Connect the App
+### Step 1: Download and Connect the App
 
 Download the vytalLink app and tap "Get Word + PIN" to get your connection details. You'll use these to connect with ChatGPT. Keep the app open while you chat.
 
-Word health
-
-PIN 123456
-
-2
-
-### Open vytalLink GPT
+### Step 2: Open vytalLink GPT
 
 Click the button below to access our custom ChatGPT designed specifically for health data analysis. Alternatively, you can go to ChatGPT, navigate to the GPTs section, and search for "vytalLink".
-
-__
 
 #### Direct Access (Recommended)
 
 Click here to open vytalLink GPT directly
 
-[ Open vytalLink GPT ](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
-
-__
+- [Open vytalLink GPT](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
 
 #### Manual Search
 
 Go to ChatGPT → GPTs → Search for "vytalLink"
 
-[ __Browse GPTs](https://chatgpt.com/gpts)
+- [Browse GPTs](https://chatgpt.com/gpts)
 
-3
-
-### Connect and Start Asking
+### Step 3: Connect and Start Asking
 
 Ask any question about your health data. When prompted, provide the Word and PIN shown in your mobile app, then start exploring your health insights!
 
@@ -70,20 +51,17 @@ Ask any question about your health data. When prompted, provide the Word and PIN
 
 Here are some questions you can ask ChatGPT about your health data
 
-What were my average heart rate and steps yesterday?
-
-Show me my sleep patterns for the last week
-
-How many calories did I burn during my last workout?
-
-Compare my activity levels between this month and last month
-
-What time did I go to bed on average this week?
-
-Show me my health trends over the past 30 days
+- What were my average heart rate and steps yesterday?
+- Show me my sleep patterns for the last week
+- How many calories did I burn during my last workout?
+- Compare my activity levels between this month and last month
+- What time did I go to bed on average this week?
+- Show me my health trends over the past 30 days
 
 ## Ready to Get Started?
 
 Download the vytalLink app and start asking ChatGPT about your health data today!
 
-__Download App [ __Try vytalLink GPT](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
+- [Download the VytalLink app](https://vytallink.xmartlabs.com/app)
+
+- [Try vytalLink GPT](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)

--- a/landing/public/chatgpt-setup.md
+++ b/landing/public/chatgpt-setup.md
@@ -1,0 +1,89 @@
+# ChatGPT Setup Guide
+
+Connect vytalLink with ChatGPT and start getting answers about your health data
+
+__ Most Popular Integration
+
+## What is vytalLink's Custom GPT?
+
+We built a custom version of ChatGPT that knows how to read health data. It understands your fitness metrics and gives you personalized insights about your wellness in your language.
+
+__ AI that understands health and fitness data
+
+__ Spots trends and patterns in your workouts
+
+__ Gives answers in plain English
+
+__ Safe connection to your health data
+
+__
+
+vytalLink GPT
+
+Show me my sleep patterns for the last week
+
+Based on your data, you've been averaging 7.2 hours of sleep per night this week. I notice you're going to bed consistently around 11 PM, which is great for maintaining a healthy sleep schedule! 📊
+
+## How to Set Up ChatGPT Integration
+
+Follow these steps to connect your health data with ChatGPT
+
+1
+
+### Download and Connect the App
+
+Download the vytalLink app and tap "Get Word + PIN" to get your connection details. You'll use these to connect with ChatGPT. Keep the app open while you chat.
+
+Word health
+
+PIN 123456
+
+2
+
+### Open vytalLink GPT
+
+Click the button below to access our custom ChatGPT designed specifically for health data analysis. Alternatively, you can go to ChatGPT, navigate to the GPTs section, and search for "vytalLink".
+
+__
+
+#### Direct Access (Recommended)
+
+Click here to open vytalLink GPT directly
+
+[ Open vytalLink GPT ](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
+
+__
+
+#### Manual Search
+
+Go to ChatGPT → GPTs → Search for "vytalLink"
+
+[ __Browse GPTs](https://chatgpt.com/gpts)
+
+3
+
+### Connect and Start Asking
+
+Ask any question about your health data. When prompted, provide the Word and PIN shown in your mobile app, then start exploring your health insights!
+
+## Example Questions
+
+Here are some questions you can ask ChatGPT about your health data
+
+What were my average heart rate and steps yesterday?
+
+Show me my sleep patterns for the last week
+
+How many calories did I burn during my last workout?
+
+Compare my activity levels between this month and last month
+
+What time did I go to bed on average this week?
+
+Show me my health trends over the past 30 days
+
+## Ready to Get Started?
+
+Download the vytalLink app and start asking ChatGPT about your health data today!
+
+__Download App [ __Try vytalLink GPT](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)

--- a/landing/public/claude-bundle-setup.html
+++ b/landing/public/claude-bundle-setup.html
@@ -105,10 +105,10 @@
                     <h3>vytalLink Mobile App</h3>
                     <p>Use the mobile app to get your connection Word + PIN for Claude Desktop.</p>
                     <div class="prereq-links">
-                        <a href="https://apps.apple.com/app/vytallink" target="_blank">
+                        <a href="https://apps.apple.com/app/id6752308627" target="_blank">
                             <i class="fab fa-apple"></i> App Store
                         </a>
-                        <a href="https://play.google.com/store/apps/details?id=com.vytallink" target="_blank">
+                        <a href="https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink" target="_blank">
                             <i class="fab fa-google-play"></i> Google Play
                         </a>
                     </div>
@@ -259,10 +259,10 @@
                     </div>
                     <p>Connecting your health data with AI, securely and privately.</p>
                     <div class="download-footer">
-                        <a href="https://apps.apple.com/app/vytallink" target="_blank">
+                        <a href="https://apps.apple.com/app/id6752308627" target="_blank">
                             <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on App Store">
                         </a>
-                        <a href="https://play.google.com/store/apps/details?id=com.vytallink" target="_blank">
+                        <a href="https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink" target="_blank">
                             <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play">
                         </a>
                     </div>

--- a/landing/public/claude-bundle-setup.md
+++ b/landing/public/claude-bundle-setup.md
@@ -2,96 +2,74 @@
 
 Install vytalLink in Claude Desktop with one double-click
 
-__ Claude Desktop
-
-__ One-click Install
-
-__ Secure Auth
-
 ## Prerequisites
 
 What you need before installing the bundle
-
-__
 
 ### vytalLink Mobile App
 
 Use the mobile app to get your connection Word + PIN for Claude Desktop.
 
-[ __App Store](https://apps.apple.com/app/vytallink) [ __Google Play](https://play.google.com/store/apps/details?id=com.vytallink)
+- [App Store](https://apps.apple.com/app/id6752308627)
+- [Google Play](https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink)
 
 ### Claude Desktop
 
 Download Claude Desktop and sign in with your Anthropic account.
 
-[ __Download Claude](https://claude.ai/download)
-
-__
+- [Download Claude](https://claude.ai/download)
 
 ### vytalLink Bundle
 
 Download the latest `.mcpb` file from GitHub. It's signed and ready to install.
 
-[ __Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media) [ __Release Notes](https://github.com/xmartlabs/vytalLink/releases/latest)
+- [Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media)
+- [Release Notes](https://github.com/xmartlabs/vytalLink/releases/latest)
 
 ## Setup Instructions
 
 Follow these steps to add vytalLink to Claude Desktop
 
-1
+### Step 1: Update and open Claude Desktop
 
-### Update and open Claude Desktop
+Launch [Claude Desktop](https://claude.ai/download) (install it if you haven't yet) and check for updates via **Settings → About → Check for updates**. Leave the app running; the bundle install requires Claude to be open.
 
-Launch [Claude Desktop](https://claude.ai/download) (install it if you haven't yet) and check for updates via **Settings → About → Check for updates**. Leave the app running; the bundle install requires Claude to be open. 
-
-2
-
-### Download the bundle
+### Step 2: Download the bundle
 
 Click the download button and save `vytallink-mcp-server.mcpb` somewhere easy to find, like your Downloads folder.
 
-[ __Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media)
-
-3
-
-### Install inside Claude Desktop
+### Step 3: Install inside Claude Desktop
 
 Double-click the bundle (or drag it into **Claude Desktop → Settings → Extensions**). Claude will show the vytalLink MCP extension details—click **Install** to confirm.
 
-__ If the bundle doesn't open automatically, right-click the file and choose **Open With → Claude Desktop**.
+> If the bundle doesn't open automatically, right-click the file and choose **Open With → Claude Desktop**.
 
-4
-
-### Restart Claude Desktop
+### Step 4: Restart Claude Desktop
 
 Once the installation finishes, quit and relaunch Claude Desktop so the extension loads correctly.
 
-5
-
-### Authenticate with Word + PIN
+### Step 5: Authenticate with Word + PIN
 
 Use the vytalLink mobile app to generate a connection Word and PIN. Ask Claude to connect using those credentials to start syncing your health data. Keep the app open while you chat.
 
-**You:** Connect to vytalLink using Word HEALTH7 and PIN sunset42 
+#### Example Conversation
+- **You:** Connect to vytalLink using Word HEALTH7 and PIN sunset42
+- **Claude:** Connection complete! You can now explore your health metrics, workouts, and sleep trends.
 
-**Claude:** Connection complete! You can now explore your health metrics, workouts, and sleep trends. 
-
-__
-
-Need the manual npm workflow or support for other MCP clients? Visit the [advanced MCP setup guide](/mcp-setup.html) for step-by-step instructions.
+> Need the manual npm workflow or support for other MCP clients? Visit the [advanced MCP setup guide](/mcp-setup.html) for step-by-step instructions.
 
 ## Troubleshooting
 
 Common issues and quick fixes
 
-### __Bundle won't open
+### Bundle won't open
 
 Right-click the file and choose **Open With → Claude Desktop**. On macOS you may need to approve the download in System Settings.
 
-### __Extension missing after install
+### Extension missing after install
 
 Restart Claude Desktop. If it still doesn't appear, reinstall the bundle and check that you're running Claude Desktop version 0.13.0 or newer.
 
-### __Authentication issues
+### Authentication issues
 
 Generate a fresh Word + PIN from the mobile app and try again. Credentials expire shortly after being issued.

--- a/landing/public/claude-bundle-setup.md
+++ b/landing/public/claude-bundle-setup.md
@@ -1,0 +1,97 @@
+# Claude Desktop Bundle Setup
+
+Install vytalLink in Claude Desktop with one double-click
+
+__ Claude Desktop
+
+__ One-click Install
+
+__ Secure Auth
+
+## Prerequisites
+
+What you need before installing the bundle
+
+__
+
+### vytalLink Mobile App
+
+Use the mobile app to get your connection Word + PIN for Claude Desktop.
+
+[ __App Store](https://apps.apple.com/app/vytallink) [ __Google Play](https://play.google.com/store/apps/details?id=com.vytallink)
+
+### Claude Desktop
+
+Download Claude Desktop and sign in with your Anthropic account.
+
+[ __Download Claude](https://claude.ai/download)
+
+__
+
+### vytalLink Bundle
+
+Download the latest `.mcpb` file from GitHub. It's signed and ready to install.
+
+[ __Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media) [ __Release Notes](https://github.com/xmartlabs/vytalLink/releases/latest)
+
+## Setup Instructions
+
+Follow these steps to add vytalLink to Claude Desktop
+
+1
+
+### Update and open Claude Desktop
+
+Launch [Claude Desktop](https://claude.ai/download) (install it if you haven't yet) and check for updates via **Settings → About → Check for updates**. Leave the app running; the bundle install requires Claude to be open. 
+
+2
+
+### Download the bundle
+
+Click the download button and save `vytallink-mcp-server.mcpb` somewhere easy to find, like your Downloads folder.
+
+[ __Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media)
+
+3
+
+### Install inside Claude Desktop
+
+Double-click the bundle (or drag it into **Claude Desktop → Settings → Extensions**). Claude will show the vytalLink MCP extension details—click **Install** to confirm.
+
+__ If the bundle doesn't open automatically, right-click the file and choose **Open With → Claude Desktop**.
+
+4
+
+### Restart Claude Desktop
+
+Once the installation finishes, quit and relaunch Claude Desktop so the extension loads correctly.
+
+5
+
+### Authenticate with Word + PIN
+
+Use the vytalLink mobile app to generate a connection Word and PIN. Ask Claude to connect using those credentials to start syncing your health data. Keep the app open while you chat.
+
+**You:** Connect to vytalLink using Word HEALTH7 and PIN sunset42 
+
+**Claude:** Connection complete! You can now explore your health metrics, workouts, and sleep trends. 
+
+__
+
+Need the manual npm workflow or support for other MCP clients? Visit the [advanced MCP setup guide](/mcp-setup.html) for step-by-step instructions.
+
+## Troubleshooting
+
+Common issues and quick fixes
+
+### __Bundle won't open
+
+Right-click the file and choose **Open With → Claude Desktop**. On macOS you may need to approve the download in System Settings.
+
+### __Extension missing after install
+
+Restart Claude Desktop. If it still doesn't appear, reinstall the bundle and check that you're running Claude Desktop version 0.13.0 or newer.
+
+### __Authentication issues
+
+Generate a fresh Word + PIN from the mobile app and try again. Credentials expire shortly after being issued.

--- a/landing/public/contact.html
+++ b/landing/public/contact.html
@@ -148,10 +148,10 @@
                     </div>
                     <p>Connecting your health data with AI, securely and privately.</p>
                     <div class="download-footer">
-                        <a href="https://apps.apple.com/app/vytallink" target="_blank">
+                        <a href="https://apps.apple.com/app/id6752308627" target="_blank">
                             <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on App Store">
                         </a>
-                        <a href="https://play.google.com/store/apps/details?id=com.vytallink" target="_blank">
+                        <a href="https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink" target="_blank">
                             <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play">
                         </a>
                     </div>

--- a/landing/public/developers.html
+++ b/landing/public/developers.html
@@ -417,7 +417,7 @@ print(result.content)</code></pre>
                     </div>
                     <p>Connecting your health data with AI, securely and privately.</p>
                     <div class="download-footer">
-                        <a href="https://apps.apple.com/us/app/vytallink/id6752308627" target="_blank">
+                        <a href="https://apps.apple.com/app/id6752308627" target="_blank">
                             <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on App Store">
                         </a>
                         <a href="https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink" target="_blank">

--- a/landing/public/developers.md
+++ b/landing/public/developers.md
@@ -2,213 +2,150 @@
 
 Developers integrate the VytalLink MCP once. End users connect through the VytalLink app with Word + PIN, then use your agent to read wearable data.
 
-Why VytalLink
+## Why VytalLink
 
-__
-
-### Zero Mobile Dev
-
-No custom app, no HealthKit entitlements, no platform accounts. Just install VytalLink and connect.
-
-__
-
-### All Major Wearables
-
-Apple Health (iOS) and Health Connect (Android) cover most devices that sync to the phone.
-
-__
-
-### Real-Time Streaming
-
-Live metrics while the VytalLink app is active. No polling, no delay.
-
-__
-
-### Privacy by Design
-
-Health data never leaves the device. No cloud copy, nothing stored server-side.
+- **Zero Mobile Dev:** No custom app, no HealthKit entitlements, no platform accounts. Just install VytalLink and connect.
+- **All Major Wearables:** Apple Health (iOS) and Health Connect (Android) cover most devices that sync to the phone.
+- **Real-Time Streaming:** Live metrics while the VytalLink app is active. No polling, no delay.
+- **Privacy by Design:** Health data never leaves the device. No cloud copy, nothing stored server-side.
 
 ## Get Started in a Few Simple Steps
 
 See the full connection flow first, then wire the MCP tools below.
 
-How it works
+### How It Works
 
-  1. Developer integrates the VytalLink MCP once
-  2. User gets Word + PIN in VytalLink
-  3. User connects the developer's agent with Word + PIN
-  4. Agent queries health data through VytalLink
+1. Developer integrates the VytalLink MCP once
+2. User gets Word + PIN in VytalLink
+3. User connects the developer's agent with Word + PIN
+4. Agent queries health data through VytalLink
 
-
-
-__Developer's agent __VytalLink app __User __Gets Word + PIN here __Asks the agent questions
-
-1
-
-### Integrate the VytalLink server
+### Step 1: Integrate the VytalLink server
 
 Start with the minimal setup below, or browse the [examples repo](https://github.com/xmartlabs/vytalLink/tree/main/examples) for complete TypeScript and Python agents.
 
-__
-
-**Recommended: Health Kit Template**
+#### Recommended: Health Kit Template
 
 The fastest path to a solid foundation. Ships with a working agent setup, CLI, Jupyter notebooks, readiness reporting, and built-in observability. Ready for production from day one.
 
-[ View on GitHub __](https://github.com/xmartlabs/vytallink-health-kit)
+- [View on GitHub](https://github.com/xmartlabs/vytallink-health-kit)
 
-agent.ts agent.py
+#### TypeScript Example
 
-__
-    
-    
-    import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-    import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-    
-    // 1. Create client and transport
-    const client = new Client({ name: "my-agent", version: "1.0.0" });
-    const transport = new StdioClientTransport({
-      command: "npx",
-      args: ["@xmartlabs/vytallink-mcp-server"],
-    });
-    
-    // 2. Connect and discover tools
-    await client.connect(transport);
-    const { tools } = await client.listTools();
-    console.log(`Connected: ${tools.length} tools available`);
+```typescript
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
-agent.ts agent.py
+// 1. Create client and transport
+const client = new Client({ name: "my-agent", version: "1.0.0" });
+const transport = new StdioClientTransport({
+  command: "npx",
+  args: ["@xmartlabs/vytallink-mcp-server"],
+});
 
-__
-    
-    
-    from mcp import ClientSession, StdioServerParameters
-    from mcp.client.stdio import stdio_client
-    
-    # 1. Connect to VytalLink MCP server
-    server_params = StdioServerParameters(
-        command="npx",
-        args=["@xmartlabs/vytallink-mcp-server"],
-    )
-    
-    async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
+// 2. Connect and discover tools
+await client.connect(transport);
+const { tools } = await client.listTools();
+console.log(`Connected: ${tools.length} tools available`);
+```
 
-2
+#### Python Example
 
-### Link the user
+```python
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# 1. Connect to VytalLink MCP server
+server_params = StdioServerParameters(
+    command="npx",
+    args=["@xmartlabs/vytallink-mcp-server"],
+)
+
+async with stdio_client(server_params) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+```
+
+### Step 2: Link the user
 
 Send your users the VytalLink app link. The user first opens VytalLink, gets a **Word + PIN** , then goes into your agent and uses those credentials there while VytalLink stays open as the bridge.
 
-__Share this link with your users [ __Download App](https://vytallink.xmartlabs.com/app)
+#### Share Link
 
-`https://vytallink.xmartlabs.com/app` __Copy
+- [Download App](https://vytallink.xmartlabs.com/app)
+
+- Direct link: `https://vytallink.xmartlabs.com/app`
 
 Your agent calls `direct_login` with the user's Word and PIN:
 
-agent.ts agent.py
+#### TypeScript Example
 
-__
-    
-    
-    await client.callTool({
-      name: "direct_login",
-      arguments: { word: "island", code: "828930" },
-    });
+```typescript
+await client.callTool({
+  name: "direct_login",
+  arguments: { word: "island", code: "828930" },
+});
+```
 
-agent.ts agent.py
+#### Python Example
 
-__
-    
-    
-    await session.call_tool(
-        "direct_login",
-        arguments={"word": "island", "code": "828930"},
-    )
+```python
+await session.call_tool(
+    "direct_login",
+    arguments={"word": "island", "code": "828930"},
+)
+```
 
-3
-
-### Start querying data
+### Step 3: Start querying data
 
 Once the user is linked, your agent can start making MCP queries right away. Here's an example that requests the last 7 days of heart rate data:
 
-agent.ts agent.py
+#### TypeScript Example
 
-__
-    
-    
-    const result = await client.callTool({
-      name: "get_health_metrics",
-      arguments: {
-        metric_type: "HEART_RATE",
-        start_date: "2025-01-01",
-        end_date: "2025-01-07",
-        aggregation: "DAILY",
-      },
-    });
-    
-    console.log(result.content);
+```typescript
+const result = await client.callTool({
+  name: "get_health_metrics",
+  arguments: {
+    metric_type: "HEART_RATE",
+    start_date: "2025-01-01",
+    end_date: "2025-01-07",
+    aggregation: "DAILY",
+  },
+});
 
-agent.ts agent.py
+console.log(result.content);
+```
 
-__
-    
-    
-    result = await session.call_tool(
-        "get_health_metrics",
-        arguments={
-            "metric_type": "HEART_RATE",
-            "start_date": "2025-01-01",
-            "end_date": "2025-01-07",
-            "aggregation": "DAILY",
-        },
-    )
-    
-    print(result.content)
+#### Python Example
+
+```python
+result = await session.call_tool(
+    "get_health_metrics",
+    arguments={
+        "metric_type": "HEART_RATE",
+        "start_date": "2025-01-01",
+        "end_date": "2025-01-07",
+        "aggregation": "DAILY",
+    },
+)
+
+print(result.content)
+```
 
 ## Good to Know
 
 Read this before you start integrating
 
-__
-
-Runtime
-
-### App Must Stay Open
-
-The VytalLink app needs to be active in the foreground to stream data. If the user backgrounds or closes the app, the data connection pauses until they return.
-
-__
-
-Performance
-
-### Send Data in Batches
-
-When querying large time ranges, the OS may throttle or kill long-running calls. Break requests into smaller date windows and merge the results in your agent.
-
-__
-
-Beta
-
-### API is Experimental
-
-The backend API works well for prototyping and testing, but it is not yet hardened for production traffic. Use it at your own risk and expect possible breaking changes.
+- **Runtime - App Must Stay Open:** The VytalLink app needs to be active in the foreground to stream data. If the user backgrounds or closes the app, the data connection pauses until they return.
+- **Performance - Send Data in Batches:** When querying large time ranges, the OS may throttle or kill long-running calls. Break requests into smaller date windows and merge the results in your agent.
+- **Beta - API is Experimental:** The backend API works well for prototyping and testing, but it is not yet hardened for production traffic. Use it at your own risk and expect possible breaking changes.
 
 ## MCP Tools Reference
 
 Three tools your agent can call after connecting
 
-### direct_login
+- `direct_login`: Logs in with the user's Word + PIN. No browser, no redirect. One tool call.
+- `get_summary`: Returns a snapshot across steps, sleep, heart rate, and more for any date range.
+- `get_health_metrics`: Query any metric by time range and aggregation: raw, hourly, or daily.
 
-Logs in with the user's Word + PIN. No browser, no redirect. One tool call.
-
-### get_summary
-
-Returns a snapshot across steps, sleep, heart rate, and more for any date range.
-
-### get_health_metrics
-
-Query any metric by time range and aggregation: raw, hourly, or daily.
-
-__ Full parameter reference, schemas, and response types in the [ API Reference __](https://api.vytallink.xmartlabs.com/docs/mcp)
+- [API Reference](https://api.vytallink.xmartlabs.com/docs/mcp)

--- a/landing/public/developers.md
+++ b/landing/public/developers.md
@@ -1,0 +1,214 @@
+# Build a Health Data Agent in 5 Minutes
+
+Developers integrate the VytalLink MCP once. End users connect through the VytalLink app with Word + PIN, then use your agent to read wearable data.
+
+Why VytalLink
+
+__
+
+### Zero Mobile Dev
+
+No custom app, no HealthKit entitlements, no platform accounts. Just install VytalLink and connect.
+
+__
+
+### All Major Wearables
+
+Apple Health (iOS) and Health Connect (Android) cover most devices that sync to the phone.
+
+__
+
+### Real-Time Streaming
+
+Live metrics while the VytalLink app is active. No polling, no delay.
+
+__
+
+### Privacy by Design
+
+Health data never leaves the device. No cloud copy, nothing stored server-side.
+
+## Get Started in a Few Simple Steps
+
+See the full connection flow first, then wire the MCP tools below.
+
+How it works
+
+  1. Developer integrates the VytalLink MCP once
+  2. User gets Word + PIN in VytalLink
+  3. User connects the developer's agent with Word + PIN
+  4. Agent queries health data through VytalLink
+
+
+
+__Developer's agent __VytalLink app __User __Gets Word + PIN here __Asks the agent questions
+
+1
+
+### Integrate the VytalLink server
+
+Start with the minimal setup below, or browse the [examples repo](https://github.com/xmartlabs/vytalLink/tree/main/examples) for complete TypeScript and Python agents.
+
+__
+
+**Recommended: Health Kit Template**
+
+The fastest path to a solid foundation. Ships with a working agent setup, CLI, Jupyter notebooks, readiness reporting, and built-in observability. Ready for production from day one.
+
+[ View on GitHub __](https://github.com/xmartlabs/vytallink-health-kit)
+
+agent.ts agent.py
+
+__
+    
+    
+    import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+    import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+    
+    // 1. Create client and transport
+    const client = new Client({ name: "my-agent", version: "1.0.0" });
+    const transport = new StdioClientTransport({
+      command: "npx",
+      args: ["@xmartlabs/vytallink-mcp-server"],
+    });
+    
+    // 2. Connect and discover tools
+    await client.connect(transport);
+    const { tools } = await client.listTools();
+    console.log(`Connected: ${tools.length} tools available`);
+
+agent.ts agent.py
+
+__
+    
+    
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    
+    # 1. Connect to VytalLink MCP server
+    server_params = StdioServerParameters(
+        command="npx",
+        args=["@xmartlabs/vytallink-mcp-server"],
+    )
+    
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+2
+
+### Link the user
+
+Send your users the VytalLink app link. The user first opens VytalLink, gets a **Word + PIN** , then goes into your agent and uses those credentials there while VytalLink stays open as the bridge.
+
+__Share this link with your users [ __Download App](https://vytallink.xmartlabs.com/app)
+
+`https://vytallink.xmartlabs.com/app` __Copy
+
+Your agent calls `direct_login` with the user's Word and PIN:
+
+agent.ts agent.py
+
+__
+    
+    
+    await client.callTool({
+      name: "direct_login",
+      arguments: { word: "island", code: "828930" },
+    });
+
+agent.ts agent.py
+
+__
+    
+    
+    await session.call_tool(
+        "direct_login",
+        arguments={"word": "island", "code": "828930"},
+    )
+
+3
+
+### Start querying data
+
+Once the user is linked, your agent can start making MCP queries right away. Here's an example that requests the last 7 days of heart rate data:
+
+agent.ts agent.py
+
+__
+    
+    
+    const result = await client.callTool({
+      name: "get_health_metrics",
+      arguments: {
+        metric_type: "HEART_RATE",
+        start_date: "2025-01-01",
+        end_date: "2025-01-07",
+        aggregation: "DAILY",
+      },
+    });
+    
+    console.log(result.content);
+
+agent.ts agent.py
+
+__
+    
+    
+    result = await session.call_tool(
+        "get_health_metrics",
+        arguments={
+            "metric_type": "HEART_RATE",
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-07",
+            "aggregation": "DAILY",
+        },
+    )
+    
+    print(result.content)
+
+## Good to Know
+
+Read this before you start integrating
+
+__
+
+Runtime
+
+### App Must Stay Open
+
+The VytalLink app needs to be active in the foreground to stream data. If the user backgrounds or closes the app, the data connection pauses until they return.
+
+__
+
+Performance
+
+### Send Data in Batches
+
+When querying large time ranges, the OS may throttle or kill long-running calls. Break requests into smaller date windows and merge the results in your agent.
+
+__
+
+Beta
+
+### API is Experimental
+
+The backend API works well for prototyping and testing, but it is not yet hardened for production traffic. Use it at your own risk and expect possible breaking changes.
+
+## MCP Tools Reference
+
+Three tools your agent can call after connecting
+
+### direct_login
+
+Logs in with the user's Word + PIN. No browser, no redirect. One tool call.
+
+### get_summary
+
+Returns a snapshot across steps, sleep, heart rate, and more for any date range.
+
+### get_health_metrics
+
+Query any metric by time range and aggregation: raw, hourly, or daily.
+
+__ Full parameter reference, schemas, and response types in the [ API Reference __](https://api.vytallink.xmartlabs.com/docs/mcp)

--- a/landing/public/faq.html
+++ b/landing/public/faq.html
@@ -113,7 +113,7 @@
           <details>
             <summary>Does VytalLink store my health data? <span class="arrow">›</span></summary>
             <div class="faq-answer">
-              <p>No. Your phone is the source of truth. The relay is stateless and does not persist health data. Only the specific fields you approve per connection are streamed to your chosen AI provider.</p>
+              <p>Your phone remains the source of truth. VytalLink is designed to relay only the health data needed for an active session, and not to keep a separate cloud copy of your metrics after that session ends.</p>
             </div>
           </details>
 
@@ -122,7 +122,7 @@
             <div class="faq-answer">
               <p>You choose who to share your data with during each session. Once shared, the data is subject to the recipient’s policies:</p>
               <ul>
-                <li>ChatGPT sessions are subject to OpenAI’s policies. Note: Our GPT integration is configured to not use your data for training.</li>
+                <li>ChatGPT sessions are subject to OpenAI’s policies and the settings or plan that apply to your account.</li>
                 <li>Claude Desktop sessions are subject to Anthropic’s policies.</li>
                 <li>For MCP clients (Cursor, VS Code, etc.), data flows to the provider behind that client.</li>
               </ul>
@@ -177,7 +177,7 @@
           <details>
             <summary>Do I need to register to use the app? <span class="arrow">›</span></summary>
             <div class="faq-answer">
-              <p>No. VytalLink is completely anonymous and does not store any user data. You can use the app without creating an account.</p>
+              <p>No account is required to start using VytalLink. The app is designed to work without a sign-up flow, so you can connect your health data without creating a separate VytalLink account.</p>
             </div>
           </details>
 
@@ -250,7 +250,7 @@
           <details>
             <summary>How is my privacy protected? <span class="arrow">›</span></summary>
             <div class="faq-answer">
-              <p>Your privacy is our priority. VytalLink uses encryption to secure your data and operates as a stateless relay, meaning no data is stored. You control what is shared and can disconnect at any time.</p>
+              <p>VytalLink is designed to keep your health data on your phone until you choose to share it with a connected assistant. Only the information needed for the current session is relayed, and you can stop sharing by ending the session or closing the app.</p>
             </div>
           </details>
 

--- a/landing/public/faq.md
+++ b/landing/public/faq.md
@@ -2,134 +2,120 @@
 
 Answers about setup, privacy, supported platforms, and more
 
-What does VytalLink do? ›
+## What does VytalLink do?
 
 VytalLink connects your fitness tracker and health apps to AI assistants like ChatGPT and Claude. You can ask questions about your sleep, workouts, steps, heart rate, and get clear answers.
 
-Where do I chat? ›
+## Where do I chat?
 
 You chat in ChatGPT on the web or in Claude Desktop on your computer. VytalLink doesn't have its own chat - it just connects your data to your AI assistant.
 
-Can I use ChatGPT on mobile? ›
+## Can I use ChatGPT on mobile?
 
 Not yet. ChatGPT on mobile doesn't work because the VytalLink app needs to stay open to share your data while you chat.
 
-Do I need to keep the app open? ›
+## Do I need to keep the app open?
 
 Yes. Keep the VytalLink app open while you chat so it can share your data with your AI assistant. Close the app and your AI can't get new data.
 
-How do I connect? What are “Word + PIN”? ›
+## How do I connect? What are “Word + PIN”?
 
-  * Tap “Get Word + PIN” in the app to generate temporary credentials for your current session.
-  * When ChatGPT or your MCP client asks, paste the Word and PIN to authenticate the bridge.
-  * These credentials expire; generate new ones anytime.
+- Tap “Get Word + PIN” in the app to generate temporary credentials for your current session.
+- When ChatGPT or your MCP client asks, paste the Word and PIN to authenticate the bridge.
+- These credentials expire; generate new ones anytime.
 
+## Does VytalLink store my health data?
 
+Your phone remains the source of truth. VytalLink is designed to relay only the health data needed for an active session, and not to keep a separate cloud copy of your metrics after that session ends.
 
-Does VytalLink store my health data? ›
-
-No. Your phone is the source of truth. The relay is stateless and does not persist health data. Only the specific fields you approve per connection are streamed to your chosen AI provider.
-
-Who receives my data during a session? ›
+## Who receives my data during a session?
 
 You choose who to share your data with during each session. Once shared, the data is subject to the recipient’s policies:
 
-  * ChatGPT sessions are subject to OpenAI’s policies. Note: Our GPT integration is configured to not use your data for training.
-  * Claude Desktop sessions are subject to Anthropic’s policies.
-  * For MCP clients (Cursor, VS Code, etc.), data flows to the provider behind that client.
-
-
+- ChatGPT sessions are subject to OpenAI’s policies and the settings or plan that apply to your account.
+- Claude Desktop sessions are subject to Anthropic’s policies.
+- For MCP clients (Cursor, VS Code, etc.), data flows to the provider behind that client.
 
 Review the provider’s terms before sharing. VytalLink does not sell or repurpose your health data.
 
-Which devices and platforms are supported? ›
+## Which devices and platforms are supported?
 
-  * **iOS:** Apple Health (Apple Watch and many third‑party wearables that sync to Health).
-  * **Android:** Health Connect (support varies by device/app; we’re expanding coverage).
-
-
+- **iOS:** Apple Health (Apple Watch and many third‑party wearables that sync to Health).
+- **Android:** Health Connect (support varies by device/app; we’re expanding coverage).
 
 If your wearable syncs to your phone’s health platform, VytalLink can make that data conversational.
 
-Do I need MCP to get started? ›
+## Do I need MCP to get started?
 
 No. The fastest path is ChatGPT (no desktop setup). MCP is available for desktop workflows and power users.
 
-What kind of questions can I ask? ›
+## What kind of questions can I ask?
 
-  * “Analyze my sleep last month vs. the previous one. Any recommendations?”
-  * “How did deep sleep change on strength days vs. cardio?”
-  * “Chart my heart rate over the last month and highlight trends.”
-  * “Are my steps up this month, and how did resting HR respond?”
+- “Analyze my sleep last month vs. the previous one. Any recommendations?”
+- “How did deep sleep change on strength days vs. cardio?”
+- “Chart my heart rate over the last month and highlight trends.”
+- “Are my steps up this month, and how did resting HR respond?”
 
-
-
-Why might results vary? ›
+## Why might results vary?
 
 AI answers depend on the model and your prompts. Try concrete time ranges, comparisons, or goals. We recommend verifying any critical insights and consulting professionals for medical decisions.
 
-How do I revoke access or disconnect? ›
+## How do I revoke access or disconnect?
 
 Stop the connection in the mobile app or simply close the app to pause the bridge. Since credentials expire and the relay is stateless, access ends when the session does. You can generate new credentials at any time.
 
-Do I need to register to use the app? ›
+## Do I need to register to use the app?
 
-No. VytalLink is completely anonymous and does not store any user data. You can use the app without creating an account.
+No account is required to start using VytalLink. The app is designed to work without a sign-up flow, so you can connect your health data without creating a separate VytalLink account.
 
-What is MCP? ›
+## What is MCP?
 
 MCP stands for Model Context Protocol. It’s a standard that allows desktop clients like Claude Desktop, Cursor, or VS Code to interact with your health data securely and efficiently. MCP clients provide advanced workflows for power users.
 
-Which client should I use? ›
+## Which client should I use?
 
-  * **ChatGPT:** Best for quick, conversational insights. No desktop setup required.
-  * **Claude Desktop:** Ideal for users who prefer Anthropic’s AI and desktop workflows.
-  * **Other MCP clients:** Use these for specific integrations or advanced setups.
-
-
+- **ChatGPT:** Best for quick, conversational insights. No desktop setup required.
+- **Claude Desktop:** Ideal for users who prefer Anthropic’s AI and desktop workflows.
+- **Other MCP clients:** Use these for specific integrations or advanced setups.
 
 Choose the client that aligns with your workflow and preferences.
 
-Troubleshooting ›
+## Troubleshooting
 
-  * **Authentication failed:** generate a fresh Word + PIN and try again.
-  * **No data visible:** ensure the app has health permissions and stays open.
-  * **MCP server not found:** confirm the MCP server/package is installed or the Claude bundle is enabled; restart the client.
-  * **Connection lost:** check network connectivity and restart the session.
+- **Authentication failed:** generate a fresh Word + PIN and try again.
+- **No data visible:** ensure the app has health permissions and stays open.
+- **MCP server not found:** confirm the MCP server/package is installed or the Claude bundle is enabled; restart the client.
+- **Connection lost:** check network connectivity and restart the session.
 
-
-
-Disclaimers ›
+## Disclaimers
 
 VytalLink does not provide medical advice, diagnosis, or treatment. For medical questions, consult a qualified professional.
 
-What is the difference between ChatGPT and MCP clients? ›
+## What is the difference between ChatGPT and MCP clients?
 
 ChatGPT is ideal for quick, conversational insights without any desktop setup. MCP clients, like Claude Desktop or VS Code, are designed for advanced workflows and professional use cases.
 
-What happens if I close the app during a session? ›
+## What happens if I close the app during a session?
 
 If you close the app, the connection to your AI assistant is paused, and no new data will be relayed. To resume, simply reopen the app and restart the session.
 
-Can I use VytalLink offline? ›
+## Can I use VytalLink offline?
 
 No, VytalLink requires an active internet connection to securely relay your health data to your AI assistant.
 
-What data does VytalLink access from my phone? ›
+## What data does VytalLink access from my phone?
 
 VytalLink accesses only the health metrics you approve, such as sleep, workouts, steps, and heart rate. You have full control over what data is shared during each session.
 
-How is my privacy protected? ›
+## How is my privacy protected?
 
-Your privacy is our priority. VytalLink uses encryption to secure your data and operates as a stateless relay, meaning no data is stored. You control what is shared and can disconnect at any time.
+VytalLink is designed to keep your health data on your phone until you choose to share it with a connected assistant. Only the information needed for the current session is relayed, and you can stop sharing by ending the session or closing the app.
 
-Why don’t I see all my data, like sleep details? ›
+## Why don’t I see all my data, like sleep details?
 
-  1. Your wearable might not sync all data to Apple Health (iOS) or Health Connect (Android). Ensure your device is properly connected and syncing.
-  2. Some wearables only share limited data. For example, they might log a sleep session but not provide detailed sleep stages (like deep or REM sleep).
+1. Your wearable might not sync all data to Apple Health (iOS) or Health Connect (Android). Ensure your device is properly connected and syncing.
+2. Some wearables only share limited data. For example, they might log a sleep session but not provide detailed sleep stages (like deep or REM sleep).
 
-
-
-Can I use VytalLink with multiple AI clients simultaneously? ›
+## Can I use VytalLink with multiple AI clients simultaneously?
 
 Yes, you can connect to multiple AI clients simultaneously. However, we recommend maintaining a single active connection for simplicity and to avoid potential data conflicts.

--- a/landing/public/faq.md
+++ b/landing/public/faq.md
@@ -1,0 +1,135 @@
+# Frequently Asked Questions
+
+Answers about setup, privacy, supported platforms, and more
+
+What does VytalLink do? ›
+
+VytalLink connects your fitness tracker and health apps to AI assistants like ChatGPT and Claude. You can ask questions about your sleep, workouts, steps, heart rate, and get clear answers.
+
+Where do I chat? ›
+
+You chat in ChatGPT on the web or in Claude Desktop on your computer. VytalLink doesn't have its own chat - it just connects your data to your AI assistant.
+
+Can I use ChatGPT on mobile? ›
+
+Not yet. ChatGPT on mobile doesn't work because the VytalLink app needs to stay open to share your data while you chat.
+
+Do I need to keep the app open? ›
+
+Yes. Keep the VytalLink app open while you chat so it can share your data with your AI assistant. Close the app and your AI can't get new data.
+
+How do I connect? What are “Word + PIN”? ›
+
+  * Tap “Get Word + PIN” in the app to generate temporary credentials for your current session.
+  * When ChatGPT or your MCP client asks, paste the Word and PIN to authenticate the bridge.
+  * These credentials expire; generate new ones anytime.
+
+
+
+Does VytalLink store my health data? ›
+
+No. Your phone is the source of truth. The relay is stateless and does not persist health data. Only the specific fields you approve per connection are streamed to your chosen AI provider.
+
+Who receives my data during a session? ›
+
+You choose who to share your data with during each session. Once shared, the data is subject to the recipient’s policies:
+
+  * ChatGPT sessions are subject to OpenAI’s policies. Note: Our GPT integration is configured to not use your data for training.
+  * Claude Desktop sessions are subject to Anthropic’s policies.
+  * For MCP clients (Cursor, VS Code, etc.), data flows to the provider behind that client.
+
+
+
+Review the provider’s terms before sharing. VytalLink does not sell or repurpose your health data.
+
+Which devices and platforms are supported? ›
+
+  * **iOS:** Apple Health (Apple Watch and many third‑party wearables that sync to Health).
+  * **Android:** Health Connect (support varies by device/app; we’re expanding coverage).
+
+
+
+If your wearable syncs to your phone’s health platform, VytalLink can make that data conversational.
+
+Do I need MCP to get started? ›
+
+No. The fastest path is ChatGPT (no desktop setup). MCP is available for desktop workflows and power users.
+
+What kind of questions can I ask? ›
+
+  * “Analyze my sleep last month vs. the previous one. Any recommendations?”
+  * “How did deep sleep change on strength days vs. cardio?”
+  * “Chart my heart rate over the last month and highlight trends.”
+  * “Are my steps up this month, and how did resting HR respond?”
+
+
+
+Why might results vary? ›
+
+AI answers depend on the model and your prompts. Try concrete time ranges, comparisons, or goals. We recommend verifying any critical insights and consulting professionals for medical decisions.
+
+How do I revoke access or disconnect? ›
+
+Stop the connection in the mobile app or simply close the app to pause the bridge. Since credentials expire and the relay is stateless, access ends when the session does. You can generate new credentials at any time.
+
+Do I need to register to use the app? ›
+
+No. VytalLink is completely anonymous and does not store any user data. You can use the app without creating an account.
+
+What is MCP? ›
+
+MCP stands for Model Context Protocol. It’s a standard that allows desktop clients like Claude Desktop, Cursor, or VS Code to interact with your health data securely and efficiently. MCP clients provide advanced workflows for power users.
+
+Which client should I use? ›
+
+  * **ChatGPT:** Best for quick, conversational insights. No desktop setup required.
+  * **Claude Desktop:** Ideal for users who prefer Anthropic’s AI and desktop workflows.
+  * **Other MCP clients:** Use these for specific integrations or advanced setups.
+
+
+
+Choose the client that aligns with your workflow and preferences.
+
+Troubleshooting ›
+
+  * **Authentication failed:** generate a fresh Word + PIN and try again.
+  * **No data visible:** ensure the app has health permissions and stays open.
+  * **MCP server not found:** confirm the MCP server/package is installed or the Claude bundle is enabled; restart the client.
+  * **Connection lost:** check network connectivity and restart the session.
+
+
+
+Disclaimers ›
+
+VytalLink does not provide medical advice, diagnosis, or treatment. For medical questions, consult a qualified professional.
+
+What is the difference between ChatGPT and MCP clients? ›
+
+ChatGPT is ideal for quick, conversational insights without any desktop setup. MCP clients, like Claude Desktop or VS Code, are designed for advanced workflows and professional use cases.
+
+What happens if I close the app during a session? ›
+
+If you close the app, the connection to your AI assistant is paused, and no new data will be relayed. To resume, simply reopen the app and restart the session.
+
+Can I use VytalLink offline? ›
+
+No, VytalLink requires an active internet connection to securely relay your health data to your AI assistant.
+
+What data does VytalLink access from my phone? ›
+
+VytalLink accesses only the health metrics you approve, such as sleep, workouts, steps, and heart rate. You have full control over what data is shared during each session.
+
+How is my privacy protected? ›
+
+Your privacy is our priority. VytalLink uses encryption to secure your data and operates as a stateless relay, meaning no data is stored. You control what is shared and can disconnect at any time.
+
+Why don’t I see all my data, like sleep details? ›
+
+  1. Your wearable might not sync all data to Apple Health (iOS) or Health Connect (Android). Ensure your device is properly connected and syncing.
+  2. Some wearables only share limited data. For example, they might log a sleep session but not provide detailed sleep stages (like deep or REM sleep).
+
+
+
+Can I use VytalLink with multiple AI clients simultaneously? ›
+
+Yes, you can connect to multiple AI clients simultaneously. However, we recommend maintaining a single active connection for simplicity and to avoid potential data conflicts.

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -1,5 +1,3 @@
-# about
-
 # About vytalLink
 
 Connecting your health data with AI assistants you already use
@@ -10,31 +8,21 @@ We think your health data should actually help you. Our goal is to let AI assist
 
 We're making health insights available to everyone by connecting your fitness tracker and health apps with AI assistants like ChatGPT and Claude.
 
-__
-
 ## How It Started
 
 vytalLink started because we were frustrated with having health data stuck in different apps with no easy way to understand what it meant.
 
 We knew AI assistants like ChatGPT and Claude could give great health insights, but they needed a safe way to access our personal data. That's what vytalLink does.
 
-__
-
 ## Our Values
-
-__
 
 ### Privacy First
 
 Your health data stays on your phone. We only share it when you ask questions and want answers.
 
-__
-
 ### User Control
 
 You choose what data to share, when to share it, and which AI assistants get to see it.
-
-__
 
 ### Open Innovation
 
@@ -46,79 +34,56 @@ vytalLink is built by [Xmartlabs](https://xmartlabs.com), a software company tha
 
 We've been building digital health solutions for over ten years, so we know how important privacy, security, and ease of use are in health apps.
 
-[Learn About Xmartlabs](https://xmartlabs.com)
-
-__
+- [Learn About Xmartlabs](https://xmartlabs.com)
 
 ---
-
-# chatgpt-setup
 
 # ChatGPT Setup Guide
 
 Connect vytalLink with ChatGPT and start getting answers about your health data
 
-__ Most Popular Integration
+_Most Popular Integration_
 
 ## What is vytalLink's Custom GPT?
 
 We built a custom version of ChatGPT that knows how to read health data. It understands your fitness metrics and gives you personalized insights about your wellness in your language.
 
-__ AI that understands health and fitness data
+- AI that understands health and fitness data
+- Spots trends and patterns in your workouts
+- Gives answers in plain English
+- Safe connection to your health data
 
-__ Spots trends and patterns in your workouts
+### Example Conversation
 
-__ Gives answers in plain English
+- **You:** Show me my sleep patterns for the last week
 
-__ Safe connection to your health data
-
-__
-
-vytalLink GPT
-
-Show me my sleep patterns for the last week
-
-Based on your data, you've been averaging 7.2 hours of sleep per night this week. I notice you're going to bed consistently around 11 PM, which is great for maintaining a healthy sleep schedule! 📊
+- **Assistant:** Based on your data, you've been averaging 7.2 hours of sleep per night this week. I notice you're going to bed consistently around 11 PM, which is great for maintaining a healthy sleep schedule! 📊
 
 ## How to Set Up ChatGPT Integration
 
 Follow these steps to connect your health data with ChatGPT
 
-1
-
-### Download and Connect the App
+### Step 1: Download and Connect the App
 
 Download the vytalLink app and tap "Get Word + PIN" to get your connection details. You'll use these to connect with ChatGPT. Keep the app open while you chat.
 
-Word health
-
-PIN 123456
-
-2
-
-### Open vytalLink GPT
+### Step 2: Open vytalLink GPT
 
 Click the button below to access our custom ChatGPT designed specifically for health data analysis. Alternatively, you can go to ChatGPT, navigate to the GPTs section, and search for "vytalLink".
-
-__
 
 #### Direct Access (Recommended)
 
 Click here to open vytalLink GPT directly
 
-[ Open vytalLink GPT ](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
-
-__
+- [Open vytalLink GPT](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
 
 #### Manual Search
 
 Go to ChatGPT → GPTs → Search for "vytalLink"
 
-[ __Browse GPTs](https://chatgpt.com/gpts)
+- [Browse GPTs](https://chatgpt.com/gpts)
 
-3
-
-### Connect and Start Asking
+### Step 3: Connect and Start Asking
 
 Ask any question about your health data. When prompted, provide the Word and PIN shown in your mobile app, then start exploring your health insights!
 
@@ -126,741 +91,599 @@ Ask any question about your health data. When prompted, provide the Word and PIN
 
 Here are some questions you can ask ChatGPT about your health data
 
-What were my average heart rate and steps yesterday?
-
-Show me my sleep patterns for the last week
-
-How many calories did I burn during my last workout?
-
-Compare my activity levels between this month and last month
-
-What time did I go to bed on average this week?
-
-Show me my health trends over the past 30 days
+- What were my average heart rate and steps yesterday?
+- Show me my sleep patterns for the last week
+- How many calories did I burn during my last workout?
+- Compare my activity levels between this month and last month
+- What time did I go to bed on average this week?
+- Show me my health trends over the past 30 days
 
 ## Ready to Get Started?
 
 Download the vytalLink app and start asking ChatGPT about your health data today!
 
-__Download App [ __Try vytalLink GPT](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
+- [Download the VytalLink app](https://vytallink.xmartlabs.com/app)
+
+- [Try vytalLink GPT](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
 
 ---
-
-# claude-bundle-setup
 
 # Claude Desktop Bundle Setup
 
 Install vytalLink in Claude Desktop with one double-click
 
-__ Claude Desktop
-
-__ One-click Install
-
-__ Secure Auth
-
 ## Prerequisites
 
 What you need before installing the bundle
-
-__
 
 ### vytalLink Mobile App
 
 Use the mobile app to get your connection Word + PIN for Claude Desktop.
 
-[ __App Store](https://apps.apple.com/app/vytallink) [ __Google Play](https://play.google.com/store/apps/details?id=com.vytallink)
+- [App Store](https://apps.apple.com/app/id6752308627)
+- [Google Play](https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink)
 
 ### Claude Desktop
 
 Download Claude Desktop and sign in with your Anthropic account.
 
-[ __Download Claude](https://claude.ai/download)
-
-__
+- [Download Claude](https://claude.ai/download)
 
 ### vytalLink Bundle
 
 Download the latest `.mcpb` file from GitHub. It's signed and ready to install.
 
-[ __Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media) [ __Release Notes](https://github.com/xmartlabs/vytalLink/releases/latest)
+- [Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media)
+- [Release Notes](https://github.com/xmartlabs/vytalLink/releases/latest)
 
 ## Setup Instructions
 
 Follow these steps to add vytalLink to Claude Desktop
 
-1
+### Step 1: Update and open Claude Desktop
 
-### Update and open Claude Desktop
+Launch [Claude Desktop](https://claude.ai/download) (install it if you haven't yet) and check for updates via **Settings → About → Check for updates**. Leave the app running; the bundle install requires Claude to be open.
 
-Launch [Claude Desktop](https://claude.ai/download) (install it if you haven't yet) and check for updates via **Settings → About → Check for updates**. Leave the app running; the bundle install requires Claude to be open. 
-
-2
-
-### Download the bundle
+### Step 2: Download the bundle
 
 Click the download button and save `vytallink-mcp-server.mcpb` somewhere easy to find, like your Downloads folder.
 
-[ __Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media)
-
-3
-
-### Install inside Claude Desktop
+### Step 3: Install inside Claude Desktop
 
 Double-click the bundle (or drag it into **Claude Desktop → Settings → Extensions**). Claude will show the vytalLink MCP extension details—click **Install** to confirm.
 
-__ If the bundle doesn't open automatically, right-click the file and choose **Open With → Claude Desktop**.
+> If the bundle doesn't open automatically, right-click the file and choose **Open With → Claude Desktop**.
 
-4
-
-### Restart Claude Desktop
+### Step 4: Restart Claude Desktop
 
 Once the installation finishes, quit and relaunch Claude Desktop so the extension loads correctly.
 
-5
-
-### Authenticate with Word + PIN
+### Step 5: Authenticate with Word + PIN
 
 Use the vytalLink mobile app to generate a connection Word and PIN. Ask Claude to connect using those credentials to start syncing your health data. Keep the app open while you chat.
 
-**You:** Connect to vytalLink using Word HEALTH7 and PIN sunset42 
+#### Example Conversation
+- **You:** Connect to vytalLink using Word HEALTH7 and PIN sunset42
+- **Claude:** Connection complete! You can now explore your health metrics, workouts, and sleep trends.
 
-**Claude:** Connection complete! You can now explore your health metrics, workouts, and sleep trends. 
-
-__
-
-Need the manual npm workflow or support for other MCP clients? Visit the [advanced MCP setup guide](/mcp-setup.html) for step-by-step instructions.
+> Need the manual npm workflow or support for other MCP clients? Visit the [advanced MCP setup guide](/mcp-setup.html) for step-by-step instructions.
 
 ## Troubleshooting
 
 Common issues and quick fixes
 
-### __Bundle won't open
+### Bundle won't open
 
 Right-click the file and choose **Open With → Claude Desktop**. On macOS you may need to approve the download in System Settings.
 
-### __Extension missing after install
+### Extension missing after install
 
 Restart Claude Desktop. If it still doesn't appear, reinstall the bundle and check that you're running Claude Desktop version 0.13.0 or newer.
 
-### __Authentication issues
+### Authentication issues
 
 Generate a fresh Word + PIN from the mobile app and try again. Credentials expire shortly after being issued.
 
 ---
 
-# developers
-
 # Build a Health Data Agent in 5 Minutes
 
 Developers integrate the VytalLink MCP once. End users connect through the VytalLink app with Word + PIN, then use your agent to read wearable data.
 
-Why VytalLink
+## Why VytalLink
 
-__
-
-### Zero Mobile Dev
-
-No custom app, no HealthKit entitlements, no platform accounts. Just install VytalLink and connect.
-
-__
-
-### All Major Wearables
-
-Apple Health (iOS) and Health Connect (Android) cover most devices that sync to the phone.
-
-__
-
-### Real-Time Streaming
-
-Live metrics while the VytalLink app is active. No polling, no delay.
-
-__
-
-### Privacy by Design
-
-Health data never leaves the device. No cloud copy, nothing stored server-side.
+- **Zero Mobile Dev:** No custom app, no HealthKit entitlements, no platform accounts. Just install VytalLink and connect.
+- **All Major Wearables:** Apple Health (iOS) and Health Connect (Android) cover most devices that sync to the phone.
+- **Real-Time Streaming:** Live metrics while the VytalLink app is active. No polling, no delay.
+- **Privacy by Design:** Health data never leaves the device. No cloud copy, nothing stored server-side.
 
 ## Get Started in a Few Simple Steps
 
 See the full connection flow first, then wire the MCP tools below.
 
-How it works
+### How It Works
 
-  1. Developer integrates the VytalLink MCP once
-  2. User gets Word + PIN in VytalLink
-  3. User connects the developer's agent with Word + PIN
-  4. Agent queries health data through VytalLink
+1. Developer integrates the VytalLink MCP once
+2. User gets Word + PIN in VytalLink
+3. User connects the developer's agent with Word + PIN
+4. Agent queries health data through VytalLink
 
-
-
-__Developer's agent __VytalLink app __User __Gets Word + PIN here __Asks the agent questions
-
-1
-
-### Integrate the VytalLink server
+### Step 1: Integrate the VytalLink server
 
 Start with the minimal setup below, or browse the [examples repo](https://github.com/xmartlabs/vytalLink/tree/main/examples) for complete TypeScript and Python agents.
 
-__
-
-**Recommended: Health Kit Template**
+#### Recommended: Health Kit Template
 
 The fastest path to a solid foundation. Ships with a working agent setup, CLI, Jupyter notebooks, readiness reporting, and built-in observability. Ready for production from day one.
 
-[ View on GitHub __](https://github.com/xmartlabs/vytallink-health-kit)
+- [View on GitHub](https://github.com/xmartlabs/vytallink-health-kit)
 
-agent.ts agent.py
+#### TypeScript Example
 
-__
-    
-    
-    import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-    import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-    
-    // 1. Create client and transport
-    const client = new Client({ name: "my-agent", version: "1.0.0" });
-    const transport = new StdioClientTransport({
-      command: "npx",
-      args: ["@xmartlabs/vytallink-mcp-server"],
-    });
-    
-    // 2. Connect and discover tools
-    await client.connect(transport);
-    const { tools } = await client.listTools();
-    console.log(`Connected: ${tools.length} tools available`);
+```typescript
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
-agent.ts agent.py
+// 1. Create client and transport
+const client = new Client({ name: "my-agent", version: "1.0.0" });
+const transport = new StdioClientTransport({
+  command: "npx",
+  args: ["@xmartlabs/vytallink-mcp-server"],
+});
 
-__
-    
-    
-    from mcp import ClientSession, StdioServerParameters
-    from mcp.client.stdio import stdio_client
-    
-    # 1. Connect to VytalLink MCP server
-    server_params = StdioServerParameters(
-        command="npx",
-        args=["@xmartlabs/vytallink-mcp-server"],
-    )
-    
-    async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
+// 2. Connect and discover tools
+await client.connect(transport);
+const { tools } = await client.listTools();
+console.log(`Connected: ${tools.length} tools available`);
+```
 
-2
+#### Python Example
 
-### Link the user
+```python
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# 1. Connect to VytalLink MCP server
+server_params = StdioServerParameters(
+    command="npx",
+    args=["@xmartlabs/vytallink-mcp-server"],
+)
+
+async with stdio_client(server_params) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+```
+
+### Step 2: Link the user
 
 Send your users the VytalLink app link. The user first opens VytalLink, gets a **Word + PIN** , then goes into your agent and uses those credentials there while VytalLink stays open as the bridge.
 
-__Share this link with your users [ __Download App](https://vytallink.xmartlabs.com/app)
+#### Share Link
 
-`https://vytallink.xmartlabs.com/app` __Copy
+- [Download App](https://vytallink.xmartlabs.com/app)
+
+- Direct link: `https://vytallink.xmartlabs.com/app`
 
 Your agent calls `direct_login` with the user's Word and PIN:
 
-agent.ts agent.py
+#### TypeScript Example
 
-__
-    
-    
-    await client.callTool({
-      name: "direct_login",
-      arguments: { word: "island", code: "828930" },
-    });
+```typescript
+await client.callTool({
+  name: "direct_login",
+  arguments: { word: "island", code: "828930" },
+});
+```
 
-agent.ts agent.py
+#### Python Example
 
-__
-    
-    
-    await session.call_tool(
-        "direct_login",
-        arguments={"word": "island", "code": "828930"},
-    )
+```python
+await session.call_tool(
+    "direct_login",
+    arguments={"word": "island", "code": "828930"},
+)
+```
 
-3
-
-### Start querying data
+### Step 3: Start querying data
 
 Once the user is linked, your agent can start making MCP queries right away. Here's an example that requests the last 7 days of heart rate data:
 
-agent.ts agent.py
+#### TypeScript Example
 
-__
-    
-    
-    const result = await client.callTool({
-      name: "get_health_metrics",
-      arguments: {
-        metric_type: "HEART_RATE",
-        start_date: "2025-01-01",
-        end_date: "2025-01-07",
-        aggregation: "DAILY",
-      },
-    });
-    
-    console.log(result.content);
+```typescript
+const result = await client.callTool({
+  name: "get_health_metrics",
+  arguments: {
+    metric_type: "HEART_RATE",
+    start_date: "2025-01-01",
+    end_date: "2025-01-07",
+    aggregation: "DAILY",
+  },
+});
 
-agent.ts agent.py
+console.log(result.content);
+```
 
-__
-    
-    
-    result = await session.call_tool(
-        "get_health_metrics",
-        arguments={
-            "metric_type": "HEART_RATE",
-            "start_date": "2025-01-01",
-            "end_date": "2025-01-07",
-            "aggregation": "DAILY",
-        },
-    )
-    
-    print(result.content)
+#### Python Example
+
+```python
+result = await session.call_tool(
+    "get_health_metrics",
+    arguments={
+        "metric_type": "HEART_RATE",
+        "start_date": "2025-01-01",
+        "end_date": "2025-01-07",
+        "aggregation": "DAILY",
+    },
+)
+
+print(result.content)
+```
 
 ## Good to Know
 
 Read this before you start integrating
 
-__
-
-Runtime
-
-### App Must Stay Open
-
-The VytalLink app needs to be active in the foreground to stream data. If the user backgrounds or closes the app, the data connection pauses until they return.
-
-__
-
-Performance
-
-### Send Data in Batches
-
-When querying large time ranges, the OS may throttle or kill long-running calls. Break requests into smaller date windows and merge the results in your agent.
-
-__
-
-Beta
-
-### API is Experimental
-
-The backend API works well for prototyping and testing, but it is not yet hardened for production traffic. Use it at your own risk and expect possible breaking changes.
+- **Runtime - App Must Stay Open:** The VytalLink app needs to be active in the foreground to stream data. If the user backgrounds or closes the app, the data connection pauses until they return.
+- **Performance - Send Data in Batches:** When querying large time ranges, the OS may throttle or kill long-running calls. Break requests into smaller date windows and merge the results in your agent.
+- **Beta - API is Experimental:** The backend API works well for prototyping and testing, but it is not yet hardened for production traffic. Use it at your own risk and expect possible breaking changes.
 
 ## MCP Tools Reference
 
 Three tools your agent can call after connecting
 
-### direct_login
+- `direct_login`: Logs in with the user's Word + PIN. No browser, no redirect. One tool call.
+- `get_summary`: Returns a snapshot across steps, sleep, heart rate, and more for any date range.
+- `get_health_metrics`: Query any metric by time range and aggregation: raw, hourly, or daily.
 
-Logs in with the user's Word + PIN. No browser, no redirect. One tool call.
-
-### get_summary
-
-Returns a snapshot across steps, sleep, heart rate, and more for any date range.
-
-### get_health_metrics
-
-Query any metric by time range and aggregation: raw, hourly, or daily.
-
-__ Full parameter reference, schemas, and response types in the [ API Reference __](https://api.vytallink.xmartlabs.com/docs/mcp)
+- [API Reference](https://api.vytallink.xmartlabs.com/docs/mcp)
 
 ---
-
-# faq
 
 # Frequently Asked Questions
 
 Answers about setup, privacy, supported platforms, and more
 
-What does VytalLink do? ›
+## What does VytalLink do?
 
 VytalLink connects your fitness tracker and health apps to AI assistants like ChatGPT and Claude. You can ask questions about your sleep, workouts, steps, heart rate, and get clear answers.
 
-Where do I chat? ›
+## Where do I chat?
 
 You chat in ChatGPT on the web or in Claude Desktop on your computer. VytalLink doesn't have its own chat - it just connects your data to your AI assistant.
 
-Can I use ChatGPT on mobile? ›
+## Can I use ChatGPT on mobile?
 
 Not yet. ChatGPT on mobile doesn't work because the VytalLink app needs to stay open to share your data while you chat.
 
-Do I need to keep the app open? ›
+## Do I need to keep the app open?
 
 Yes. Keep the VytalLink app open while you chat so it can share your data with your AI assistant. Close the app and your AI can't get new data.
 
-How do I connect? What are “Word + PIN”? ›
+## How do I connect? What are “Word + PIN”?
 
-  * Tap “Get Word + PIN” in the app to generate temporary credentials for your current session.
-  * When ChatGPT or your MCP client asks, paste the Word and PIN to authenticate the bridge.
-  * These credentials expire; generate new ones anytime.
+- Tap “Get Word + PIN” in the app to generate temporary credentials for your current session.
+- When ChatGPT or your MCP client asks, paste the Word and PIN to authenticate the bridge.
+- These credentials expire; generate new ones anytime.
 
+## Does VytalLink store my health data?
 
+Your phone remains the source of truth. VytalLink is designed to relay only the health data needed for an active session, and not to keep a separate cloud copy of your metrics after that session ends.
 
-Does VytalLink store my health data? ›
-
-No. Your phone is the source of truth. The relay is stateless and does not persist health data. Only the specific fields you approve per connection are streamed to your chosen AI provider.
-
-Who receives my data during a session? ›
+## Who receives my data during a session?
 
 You choose who to share your data with during each session. Once shared, the data is subject to the recipient’s policies:
 
-  * ChatGPT sessions are subject to OpenAI’s policies. Note: Our GPT integration is configured to not use your data for training.
-  * Claude Desktop sessions are subject to Anthropic’s policies.
-  * For MCP clients (Cursor, VS Code, etc.), data flows to the provider behind that client.
-
-
+- ChatGPT sessions are subject to OpenAI’s policies and the settings or plan that apply to your account.
+- Claude Desktop sessions are subject to Anthropic’s policies.
+- For MCP clients (Cursor, VS Code, etc.), data flows to the provider behind that client.
 
 Review the provider’s terms before sharing. VytalLink does not sell or repurpose your health data.
 
-Which devices and platforms are supported? ›
+## Which devices and platforms are supported?
 
-  * **iOS:** Apple Health (Apple Watch and many third‑party wearables that sync to Health).
-  * **Android:** Health Connect (support varies by device/app; we’re expanding coverage).
-
-
+- **iOS:** Apple Health (Apple Watch and many third‑party wearables that sync to Health).
+- **Android:** Health Connect (support varies by device/app; we’re expanding coverage).
 
 If your wearable syncs to your phone’s health platform, VytalLink can make that data conversational.
 
-Do I need MCP to get started? ›
+## Do I need MCP to get started?
 
 No. The fastest path is ChatGPT (no desktop setup). MCP is available for desktop workflows and power users.
 
-What kind of questions can I ask? ›
+## What kind of questions can I ask?
 
-  * “Analyze my sleep last month vs. the previous one. Any recommendations?”
-  * “How did deep sleep change on strength days vs. cardio?”
-  * “Chart my heart rate over the last month and highlight trends.”
-  * “Are my steps up this month, and how did resting HR respond?”
+- “Analyze my sleep last month vs. the previous one. Any recommendations?”
+- “How did deep sleep change on strength days vs. cardio?”
+- “Chart my heart rate over the last month and highlight trends.”
+- “Are my steps up this month, and how did resting HR respond?”
 
-
-
-Why might results vary? ›
+## Why might results vary?
 
 AI answers depend on the model and your prompts. Try concrete time ranges, comparisons, or goals. We recommend verifying any critical insights and consulting professionals for medical decisions.
 
-How do I revoke access or disconnect? ›
+## How do I revoke access or disconnect?
 
 Stop the connection in the mobile app or simply close the app to pause the bridge. Since credentials expire and the relay is stateless, access ends when the session does. You can generate new credentials at any time.
 
-Do I need to register to use the app? ›
+## Do I need to register to use the app?
 
-No. VytalLink is completely anonymous and does not store any user data. You can use the app without creating an account.
+No account is required to start using VytalLink. The app is designed to work without a sign-up flow, so you can connect your health data without creating a separate VytalLink account.
 
-What is MCP? ›
+## What is MCP?
 
 MCP stands for Model Context Protocol. It’s a standard that allows desktop clients like Claude Desktop, Cursor, or VS Code to interact with your health data securely and efficiently. MCP clients provide advanced workflows for power users.
 
-Which client should I use? ›
+## Which client should I use?
 
-  * **ChatGPT:** Best for quick, conversational insights. No desktop setup required.
-  * **Claude Desktop:** Ideal for users who prefer Anthropic’s AI and desktop workflows.
-  * **Other MCP clients:** Use these for specific integrations or advanced setups.
-
-
+- **ChatGPT:** Best for quick, conversational insights. No desktop setup required.
+- **Claude Desktop:** Ideal for users who prefer Anthropic’s AI and desktop workflows.
+- **Other MCP clients:** Use these for specific integrations or advanced setups.
 
 Choose the client that aligns with your workflow and preferences.
 
-Troubleshooting ›
+## Troubleshooting
 
-  * **Authentication failed:** generate a fresh Word + PIN and try again.
-  * **No data visible:** ensure the app has health permissions and stays open.
-  * **MCP server not found:** confirm the MCP server/package is installed or the Claude bundle is enabled; restart the client.
-  * **Connection lost:** check network connectivity and restart the session.
+- **Authentication failed:** generate a fresh Word + PIN and try again.
+- **No data visible:** ensure the app has health permissions and stays open.
+- **MCP server not found:** confirm the MCP server/package is installed or the Claude bundle is enabled; restart the client.
+- **Connection lost:** check network connectivity and restart the session.
 
-
-
-Disclaimers ›
+## Disclaimers
 
 VytalLink does not provide medical advice, diagnosis, or treatment. For medical questions, consult a qualified professional.
 
-What is the difference between ChatGPT and MCP clients? ›
+## What is the difference between ChatGPT and MCP clients?
 
 ChatGPT is ideal for quick, conversational insights without any desktop setup. MCP clients, like Claude Desktop or VS Code, are designed for advanced workflows and professional use cases.
 
-What happens if I close the app during a session? ›
+## What happens if I close the app during a session?
 
 If you close the app, the connection to your AI assistant is paused, and no new data will be relayed. To resume, simply reopen the app and restart the session.
 
-Can I use VytalLink offline? ›
+## Can I use VytalLink offline?
 
 No, VytalLink requires an active internet connection to securely relay your health data to your AI assistant.
 
-What data does VytalLink access from my phone? ›
+## What data does VytalLink access from my phone?
 
 VytalLink accesses only the health metrics you approve, such as sleep, workouts, steps, and heart rate. You have full control over what data is shared during each session.
 
-How is my privacy protected? ›
+## How is my privacy protected?
 
-Your privacy is our priority. VytalLink uses encryption to secure your data and operates as a stateless relay, meaning no data is stored. You control what is shared and can disconnect at any time.
+VytalLink is designed to keep your health data on your phone until you choose to share it with a connected assistant. Only the information needed for the current session is relayed, and you can stop sharing by ending the session or closing the app.
 
-Why don’t I see all my data, like sleep details? ›
+## Why don’t I see all my data, like sleep details?
 
-  1. Your wearable might not sync all data to Apple Health (iOS) or Health Connect (Android). Ensure your device is properly connected and syncing.
-  2. Some wearables only share limited data. For example, they might log a sleep session but not provide detailed sleep stages (like deep or REM sleep).
+1. Your wearable might not sync all data to Apple Health (iOS) or Health Connect (Android). Ensure your device is properly connected and syncing.
+2. Some wearables only share limited data. For example, they might log a sleep session but not provide detailed sleep stages (like deep or REM sleep).
 
-
-
-Can I use VytalLink with multiple AI clients simultaneously? ›
+## Can I use VytalLink with multiple AI clients simultaneously?
 
 Yes, you can connect to multiple AI clients simultaneously. However, we recommend maintaining a single active connection for simplicity and to avoid potential data conflicts.
 
 ---
 
-# mcp-setup
-
 # MCP Setup Guide
 
 Connect vytalLink to any MCP client in a few minutes
 
-Claude Desktop
-
-Cursor
-
-VS Code
-
-__ Any MCP Client
+Supported clients: Claude Desktop, Cursor, VS Code, and other MCP-compatible clients.
 
 ## Prerequisites
 
 What you need before setting up MCP
 
-__
-
 ### vytalLink Mobile App
 
 Download and set up the vytalLink mobile app to generate your connection Word + PIN.
 
-[ __App Store](https://apps.apple.com/app/id6752308627) [ __Google Play](https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink)
-
-__
+- [App Store](https://apps.apple.com/app/id6752308627)
+- [Google Play](https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink)
 
 ### Node.js & npm
 
 Required to install and run the vytalLink MCP server package.
 
-[ __Download Node.js](https://nodejs.org/)
-
-__
+- [Download Node.js](https://nodejs.org/)
 
 ### MCP Client
 
 Any MCP-compatible client like Claude Desktop, Cursor, or VS Code with MCP support.
 
-[ Claude Desktop ](https://claude.ai/download)
+- [Claude Desktop](https://claude.ai/download)
 
 ## Setup Instructions
 
 Choose your MCP client and follow the setup guide
 
-Claude Desktop  Cursor  VS Code  __Other MCP Clients
+## Claude Desktop
 
-1
+### Step 1: Install the MCP Server
 
-### Install the MCP Server
-
-__ Looking for the one-click experience? Use the [Claude Desktop bundle guide](/claude-bundle-setup.html) instead.
+> Looking for the one-click experience? Use the [Claude Desktop bundle guide](/claude-bundle-setup.html) instead.
 
 Install the vytalLink MCP server package globally using npm:
 
-Terminal __
-    
-    
-    npm install -g @xmartlabs/vytallink-mcp-server
+#### Terminal
 
-2
+```
+npm install -g @xmartlabs/vytallink-mcp-server
+```
 
-### Configure Claude Desktop
+### Step 2: Configure Claude Desktop
 
 Add vytalLink to your Claude Desktop configuration file:
 
-#### Configuration file location:
+#### Configuration File Locations
 
-macOS Windows Linux
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux:** `~/.config/claude/claude_desktop_config.json`
 
-`~/Library/Application Support/Claude/claude_desktop_config.json`
+#### claude_desktop_config.json
 
-`%APPDATA%\Claude\claude_desktop_config.json`
-
-`~/.config/claude/claude_desktop_config.json`
-
-claude_desktop_config.json __
-    
-    
-    {
-      "mcpServers": {
-        "vytalLink": {
-          "command": "npx",
-          "args": [
-            "@xmartlabs/vytallink-mcp-server"
-          ]
-        }
-      }
+```json
+{
+  "mcpServers": {
+    "vytalLink": {
+      "command": "npx",
+      "args": [
+        "@xmartlabs/vytallink-mcp-server"
+      ]
     }
+  }
+}
+```
 
-3
-
-### Restart Claude Desktop
+### Step 3: Restart Claude Desktop
 
 Close and restart Claude Desktop to load the new MCP server configuration.
 
-4
-
-### Connect Your Health Data
+### Step 4: Connect Your Health Data
 
 Use the Word + PIN from your vytalLink mobile app to authenticate:
 
-**You:** Connect to my health data using Word HEALTH7 and PIN sunset42 
+#### Example Conversation
+- **You:** Connect to my health data using Word HEALTH7 and PIN sunset42
+- **Claude:** I've successfully connected to your health data! I can now help you analyze your fitness metrics, sleep patterns, and wellness trends.
 
-**Claude:** I've successfully connected to your health data! I can now help you analyze your fitness metrics, sleep patterns, and wellness trends. 
+## Cursor
 
-1
-
-### Install the MCP Server
+### Step 1: Install the MCP Server
 
 Install the vytalLink MCP server package:
 
-Terminal __
-    
-    
-    npm install -g @xmartlabs/vytallink-mcp-server
+#### Terminal
 
-2
+```
+npm install -g @xmartlabs/vytallink-mcp-server
+```
 
-### Configure Cursor
+### Step 2: Configure Cursor
 
 Add vytalLink to your Cursor MCP configuration:
 
-Cursor MCP Configuration __
-    
-    
-    {
-      "mcpServers": {
-        "vytalLink": {
-          "command": "npx",
-          "args": [
-            "@xmartlabs/vytallink-mcp-server"
-          ]
-        }
-      }
+#### Cursor MCP Configuration
+
+```json
+{
+  "mcpServers": {
+    "vytalLink": {
+      "command": "npx",
+      "args": [
+        "@xmartlabs/vytallink-mcp-server"
+      ]
     }
+  }
+}
+```
 
-3
-
-### Enable MCP in Cursor
+### Step 3: Enable MCP in Cursor
 
 Make sure MCP is enabled in Cursor settings and restart the application.
 
-__ Check Cursor's documentation for the latest MCP setup instructions
+> Check Cursor's documentation for the latest MCP setup instructions
 
-1
+## VS Code
 
-### Install MCP Extension
+### Step 1: Install MCP Extension
 
 Install an MCP-compatible extension in VS Code (availability may vary).
 
-__ MCP support in VS Code is evolving. Check the VS Code marketplace for MCP extensions.
+> MCP support in VS Code is evolving. Check the VS Code marketplace for MCP extensions.
 
-2
+### Step 2: Install the MCP Server
 
-### Install the MCP Server
+#### Terminal
 
-Terminal __
-    
-    
-    npm install -g @xmartlabs/vytallink-mcp-server
+```
+npm install -g @xmartlabs/vytallink-mcp-server
+```
 
-3
-
-### Configure MCP Server
+### Step 3: Configure MCP Server
 
 Create or edit the MCP configuration file in your VS Code user directory:
 
-macOS Windows Linux
+#### Configuration File Locations
 
-`~/Library/Application Support/Code/User/mcp.json`
+- **macOS:** `~/Library/Application Support/Code/User/mcp.json`
+- **Windows:** `%APPDATA%\Code\User\mcp.json`
+- **Linux:** `~/.config/Code/User/mcp.json`
 
-`%APPDATA%\Code\User\mcp.json`
+#### mcp.json
 
-`~/.config/Code/User/mcp.json`
-
-mcp.json __
-    
-    
-    {
-      "servers": {
-        "vytalLink": {
-          "command": "npx",
-          "args": ["@xmartlabs/vytallink-mcp-server"]
-        }
-      }
+```json
+{
+  "servers": {
+    "vytalLink": {
+      "command": "npx",
+      "args": ["@xmartlabs/vytallink-mcp-server"]
     }
+  }
+}
+```
 
-4
-
-### Restart VS Code
+### Step 4: Restart VS Code
 
 Close and restart VS Code to load the new MCP server configuration.
 
-1
+## Other MCP Clients
 
-### Install the MCP Server
+### Step 1: Install the MCP Server
 
-Terminal __
-    
-    
-    npm install -g @xmartlabs/vytallink-mcp-server
+#### Terminal
 
-2
+```
+npm install -g @xmartlabs/vytallink-mcp-server
+```
 
-### Generic MCP Configuration
+### Step 2: Generic MCP Configuration
 
 Use this configuration template for any MCP-compatible client:
 
-MCP Configuration Template __
-    
-    
-    {
-      "mcpServers": {
-        "vytalLink": {
-          "command": "npx",
-          "args": [
-            "@xmartlabs/vytallink-mcp-server"
-          ]
-        }
-      }
+#### MCP Configuration Template
+
+```json
+{
+  "mcpServers": {
+    "vytalLink": {
+      "command": "npx",
+      "args": [
+        "@xmartlabs/vytallink-mcp-server"
+      ]
     }
+  }
+}
+```
 
-3
-
-### Client-Specific Setup
+### Step 3: Client-Specific Setup
 
 Follow your MCP client's documentation to:
 
-  * Add the server configuration
-  * Enable MCP functionality
-  * Restart the application
-
-
+- Add the server configuration
+- Enable MCP functionality
+- Restart the application
 
 ## Troubleshooting
 
 Common issues and solutions
 
-### __MCP server not found
+### MCP server not found
 
 Verify that @xmartlabs/vytallink-mcp-server is installed globally and npx is available in your PATH.
 
-### __Authentication failed
+### Authentication failed
 
 Check that you're using the correct Word + PIN from your vytalLink mobile app. Credentials expire after some time.
 
-### __No health data
+### No health data
 
 Ensure your mobile app has permission to access health data and is actively syncing with your device's health platform.
 
-### Need More Help?
+## Need More Help?
 
 If you're still having issues, check our documentation or reach out for support:
 
-[ __GitHub Repository](https://github.com/xmartlabs/vytalLink) [ __Contact Support](https://xmartlabs.com)
+- [GitHub Repository](https://github.com/xmartlabs/vytalLink)
+- [Contact Support](https://xmartlabs.com)

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -1,0 +1,866 @@
+# about
+
+# About vytalLink
+
+Connecting your health data with AI assistants you already use
+
+## Our Mission
+
+We think your health data should actually help you. Our goal is to let AI assistants read your health info safely, privately, and only when you want them to.
+
+We're making health insights available to everyone by connecting your fitness tracker and health apps with AI assistants like ChatGPT and Claude.
+
+__
+
+## How It Started
+
+vytalLink started because we were frustrated with having health data stuck in different apps with no easy way to understand what it meant.
+
+We knew AI assistants like ChatGPT and Claude could give great health insights, but they needed a safe way to access our personal data. That's what vytalLink does.
+
+__
+
+## Our Values
+
+__
+
+### Privacy First
+
+Your health data stays on your phone. We only share it when you ask questions and want answers.
+
+__
+
+### User Control
+
+You choose what data to share, when to share it, and which AI assistants get to see it.
+
+__
+
+### Open Innovation
+
+We use open standards like MCP so vytalLink works with different AI platforms.
+
+## Built by Xmartlabs
+
+vytalLink is built by [Xmartlabs](https://xmartlabs.com), a software company that specializes in mobile apps, AI integration, and health tech.
+
+We've been building digital health solutions for over ten years, so we know how important privacy, security, and ease of use are in health apps.
+
+[Learn About Xmartlabs](https://xmartlabs.com)
+
+__
+
+---
+
+# chatgpt-setup
+
+# ChatGPT Setup Guide
+
+Connect vytalLink with ChatGPT and start getting answers about your health data
+
+__ Most Popular Integration
+
+## What is vytalLink's Custom GPT?
+
+We built a custom version of ChatGPT that knows how to read health data. It understands your fitness metrics and gives you personalized insights about your wellness in your language.
+
+__ AI that understands health and fitness data
+
+__ Spots trends and patterns in your workouts
+
+__ Gives answers in plain English
+
+__ Safe connection to your health data
+
+__
+
+vytalLink GPT
+
+Show me my sleep patterns for the last week
+
+Based on your data, you've been averaging 7.2 hours of sleep per night this week. I notice you're going to bed consistently around 11 PM, which is great for maintaining a healthy sleep schedule! 📊
+
+## How to Set Up ChatGPT Integration
+
+Follow these steps to connect your health data with ChatGPT
+
+1
+
+### Download and Connect the App
+
+Download the vytalLink app and tap "Get Word + PIN" to get your connection details. You'll use these to connect with ChatGPT. Keep the app open while you chat.
+
+Word health
+
+PIN 123456
+
+2
+
+### Open vytalLink GPT
+
+Click the button below to access our custom ChatGPT designed specifically for health data analysis. Alternatively, you can go to ChatGPT, navigate to the GPTs section, and search for "vytalLink".
+
+__
+
+#### Direct Access (Recommended)
+
+Click here to open vytalLink GPT directly
+
+[ Open vytalLink GPT ](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
+
+__
+
+#### Manual Search
+
+Go to ChatGPT → GPTs → Search for "vytalLink"
+
+[ __Browse GPTs](https://chatgpt.com/gpts)
+
+3
+
+### Connect and Start Asking
+
+Ask any question about your health data. When prompted, provide the Word and PIN shown in your mobile app, then start exploring your health insights!
+
+## Example Questions
+
+Here are some questions you can ask ChatGPT about your health data
+
+What were my average heart rate and steps yesterday?
+
+Show me my sleep patterns for the last week
+
+How many calories did I burn during my last workout?
+
+Compare my activity levels between this month and last month
+
+What time did I go to bed on average this week?
+
+Show me my health trends over the past 30 days
+
+## Ready to Get Started?
+
+Download the vytalLink app and start asking ChatGPT about your health data today!
+
+__Download App [ __Try vytalLink GPT](https://chatgpt.com/g/g-68c2fb58447c8191b5af624f6b33bdd6-vytallink)
+
+---
+
+# claude-bundle-setup
+
+# Claude Desktop Bundle Setup
+
+Install vytalLink in Claude Desktop with one double-click
+
+__ Claude Desktop
+
+__ One-click Install
+
+__ Secure Auth
+
+## Prerequisites
+
+What you need before installing the bundle
+
+__
+
+### vytalLink Mobile App
+
+Use the mobile app to get your connection Word + PIN for Claude Desktop.
+
+[ __App Store](https://apps.apple.com/app/vytallink) [ __Google Play](https://play.google.com/store/apps/details?id=com.vytallink)
+
+### Claude Desktop
+
+Download Claude Desktop and sign in with your Anthropic account.
+
+[ __Download Claude](https://claude.ai/download)
+
+__
+
+### vytalLink Bundle
+
+Download the latest `.mcpb` file from GitHub. It's signed and ready to install.
+
+[ __Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media) [ __Release Notes](https://github.com/xmartlabs/vytalLink/releases/latest)
+
+## Setup Instructions
+
+Follow these steps to add vytalLink to Claude Desktop
+
+1
+
+### Update and open Claude Desktop
+
+Launch [Claude Desktop](https://claude.ai/download) (install it if you haven't yet) and check for updates via **Settings → About → Check for updates**. Leave the app running; the bundle install requires Claude to be open. 
+
+2
+
+### Download the bundle
+
+Click the download button and save `vytallink-mcp-server.mcpb` somewhere easy to find, like your Downloads folder.
+
+[ __Download Bundle](https://firebasestorage.googleapis.com/v0/b/vytallink.firebasestorage.app/o/releases%2FVytalLink%20MCP%20Server.mcpb?alt=media)
+
+3
+
+### Install inside Claude Desktop
+
+Double-click the bundle (or drag it into **Claude Desktop → Settings → Extensions**). Claude will show the vytalLink MCP extension details—click **Install** to confirm.
+
+__ If the bundle doesn't open automatically, right-click the file and choose **Open With → Claude Desktop**.
+
+4
+
+### Restart Claude Desktop
+
+Once the installation finishes, quit and relaunch Claude Desktop so the extension loads correctly.
+
+5
+
+### Authenticate with Word + PIN
+
+Use the vytalLink mobile app to generate a connection Word and PIN. Ask Claude to connect using those credentials to start syncing your health data. Keep the app open while you chat.
+
+**You:** Connect to vytalLink using Word HEALTH7 and PIN sunset42 
+
+**Claude:** Connection complete! You can now explore your health metrics, workouts, and sleep trends. 
+
+__
+
+Need the manual npm workflow or support for other MCP clients? Visit the [advanced MCP setup guide](/mcp-setup.html) for step-by-step instructions.
+
+## Troubleshooting
+
+Common issues and quick fixes
+
+### __Bundle won't open
+
+Right-click the file and choose **Open With → Claude Desktop**. On macOS you may need to approve the download in System Settings.
+
+### __Extension missing after install
+
+Restart Claude Desktop. If it still doesn't appear, reinstall the bundle and check that you're running Claude Desktop version 0.13.0 or newer.
+
+### __Authentication issues
+
+Generate a fresh Word + PIN from the mobile app and try again. Credentials expire shortly after being issued.
+
+---
+
+# developers
+
+# Build a Health Data Agent in 5 Minutes
+
+Developers integrate the VytalLink MCP once. End users connect through the VytalLink app with Word + PIN, then use your agent to read wearable data.
+
+Why VytalLink
+
+__
+
+### Zero Mobile Dev
+
+No custom app, no HealthKit entitlements, no platform accounts. Just install VytalLink and connect.
+
+__
+
+### All Major Wearables
+
+Apple Health (iOS) and Health Connect (Android) cover most devices that sync to the phone.
+
+__
+
+### Real-Time Streaming
+
+Live metrics while the VytalLink app is active. No polling, no delay.
+
+__
+
+### Privacy by Design
+
+Health data never leaves the device. No cloud copy, nothing stored server-side.
+
+## Get Started in a Few Simple Steps
+
+See the full connection flow first, then wire the MCP tools below.
+
+How it works
+
+  1. Developer integrates the VytalLink MCP once
+  2. User gets Word + PIN in VytalLink
+  3. User connects the developer's agent with Word + PIN
+  4. Agent queries health data through VytalLink
+
+
+
+__Developer's agent __VytalLink app __User __Gets Word + PIN here __Asks the agent questions
+
+1
+
+### Integrate the VytalLink server
+
+Start with the minimal setup below, or browse the [examples repo](https://github.com/xmartlabs/vytalLink/tree/main/examples) for complete TypeScript and Python agents.
+
+__
+
+**Recommended: Health Kit Template**
+
+The fastest path to a solid foundation. Ships with a working agent setup, CLI, Jupyter notebooks, readiness reporting, and built-in observability. Ready for production from day one.
+
+[ View on GitHub __](https://github.com/xmartlabs/vytallink-health-kit)
+
+agent.ts agent.py
+
+__
+    
+    
+    import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+    import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+    
+    // 1. Create client and transport
+    const client = new Client({ name: "my-agent", version: "1.0.0" });
+    const transport = new StdioClientTransport({
+      command: "npx",
+      args: ["@xmartlabs/vytallink-mcp-server"],
+    });
+    
+    // 2. Connect and discover tools
+    await client.connect(transport);
+    const { tools } = await client.listTools();
+    console.log(`Connected: ${tools.length} tools available`);
+
+agent.ts agent.py
+
+__
+    
+    
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    
+    # 1. Connect to VytalLink MCP server
+    server_params = StdioServerParameters(
+        command="npx",
+        args=["@xmartlabs/vytallink-mcp-server"],
+    )
+    
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+2
+
+### Link the user
+
+Send your users the VytalLink app link. The user first opens VytalLink, gets a **Word + PIN** , then goes into your agent and uses those credentials there while VytalLink stays open as the bridge.
+
+__Share this link with your users [ __Download App](https://vytallink.xmartlabs.com/app)
+
+`https://vytallink.xmartlabs.com/app` __Copy
+
+Your agent calls `direct_login` with the user's Word and PIN:
+
+agent.ts agent.py
+
+__
+    
+    
+    await client.callTool({
+      name: "direct_login",
+      arguments: { word: "island", code: "828930" },
+    });
+
+agent.ts agent.py
+
+__
+    
+    
+    await session.call_tool(
+        "direct_login",
+        arguments={"word": "island", "code": "828930"},
+    )
+
+3
+
+### Start querying data
+
+Once the user is linked, your agent can start making MCP queries right away. Here's an example that requests the last 7 days of heart rate data:
+
+agent.ts agent.py
+
+__
+    
+    
+    const result = await client.callTool({
+      name: "get_health_metrics",
+      arguments: {
+        metric_type: "HEART_RATE",
+        start_date: "2025-01-01",
+        end_date: "2025-01-07",
+        aggregation: "DAILY",
+      },
+    });
+    
+    console.log(result.content);
+
+agent.ts agent.py
+
+__
+    
+    
+    result = await session.call_tool(
+        "get_health_metrics",
+        arguments={
+            "metric_type": "HEART_RATE",
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-07",
+            "aggregation": "DAILY",
+        },
+    )
+    
+    print(result.content)
+
+## Good to Know
+
+Read this before you start integrating
+
+__
+
+Runtime
+
+### App Must Stay Open
+
+The VytalLink app needs to be active in the foreground to stream data. If the user backgrounds or closes the app, the data connection pauses until they return.
+
+__
+
+Performance
+
+### Send Data in Batches
+
+When querying large time ranges, the OS may throttle or kill long-running calls. Break requests into smaller date windows and merge the results in your agent.
+
+__
+
+Beta
+
+### API is Experimental
+
+The backend API works well for prototyping and testing, but it is not yet hardened for production traffic. Use it at your own risk and expect possible breaking changes.
+
+## MCP Tools Reference
+
+Three tools your agent can call after connecting
+
+### direct_login
+
+Logs in with the user's Word + PIN. No browser, no redirect. One tool call.
+
+### get_summary
+
+Returns a snapshot across steps, sleep, heart rate, and more for any date range.
+
+### get_health_metrics
+
+Query any metric by time range and aggregation: raw, hourly, or daily.
+
+__ Full parameter reference, schemas, and response types in the [ API Reference __](https://api.vytallink.xmartlabs.com/docs/mcp)
+
+---
+
+# faq
+
+# Frequently Asked Questions
+
+Answers about setup, privacy, supported platforms, and more
+
+What does VytalLink do? ›
+
+VytalLink connects your fitness tracker and health apps to AI assistants like ChatGPT and Claude. You can ask questions about your sleep, workouts, steps, heart rate, and get clear answers.
+
+Where do I chat? ›
+
+You chat in ChatGPT on the web or in Claude Desktop on your computer. VytalLink doesn't have its own chat - it just connects your data to your AI assistant.
+
+Can I use ChatGPT on mobile? ›
+
+Not yet. ChatGPT on mobile doesn't work because the VytalLink app needs to stay open to share your data while you chat.
+
+Do I need to keep the app open? ›
+
+Yes. Keep the VytalLink app open while you chat so it can share your data with your AI assistant. Close the app and your AI can't get new data.
+
+How do I connect? What are “Word + PIN”? ›
+
+  * Tap “Get Word + PIN” in the app to generate temporary credentials for your current session.
+  * When ChatGPT or your MCP client asks, paste the Word and PIN to authenticate the bridge.
+  * These credentials expire; generate new ones anytime.
+
+
+
+Does VytalLink store my health data? ›
+
+No. Your phone is the source of truth. The relay is stateless and does not persist health data. Only the specific fields you approve per connection are streamed to your chosen AI provider.
+
+Who receives my data during a session? ›
+
+You choose who to share your data with during each session. Once shared, the data is subject to the recipient’s policies:
+
+  * ChatGPT sessions are subject to OpenAI’s policies. Note: Our GPT integration is configured to not use your data for training.
+  * Claude Desktop sessions are subject to Anthropic’s policies.
+  * For MCP clients (Cursor, VS Code, etc.), data flows to the provider behind that client.
+
+
+
+Review the provider’s terms before sharing. VytalLink does not sell or repurpose your health data.
+
+Which devices and platforms are supported? ›
+
+  * **iOS:** Apple Health (Apple Watch and many third‑party wearables that sync to Health).
+  * **Android:** Health Connect (support varies by device/app; we’re expanding coverage).
+
+
+
+If your wearable syncs to your phone’s health platform, VytalLink can make that data conversational.
+
+Do I need MCP to get started? ›
+
+No. The fastest path is ChatGPT (no desktop setup). MCP is available for desktop workflows and power users.
+
+What kind of questions can I ask? ›
+
+  * “Analyze my sleep last month vs. the previous one. Any recommendations?”
+  * “How did deep sleep change on strength days vs. cardio?”
+  * “Chart my heart rate over the last month and highlight trends.”
+  * “Are my steps up this month, and how did resting HR respond?”
+
+
+
+Why might results vary? ›
+
+AI answers depend on the model and your prompts. Try concrete time ranges, comparisons, or goals. We recommend verifying any critical insights and consulting professionals for medical decisions.
+
+How do I revoke access or disconnect? ›
+
+Stop the connection in the mobile app or simply close the app to pause the bridge. Since credentials expire and the relay is stateless, access ends when the session does. You can generate new credentials at any time.
+
+Do I need to register to use the app? ›
+
+No. VytalLink is completely anonymous and does not store any user data. You can use the app without creating an account.
+
+What is MCP? ›
+
+MCP stands for Model Context Protocol. It’s a standard that allows desktop clients like Claude Desktop, Cursor, or VS Code to interact with your health data securely and efficiently. MCP clients provide advanced workflows for power users.
+
+Which client should I use? ›
+
+  * **ChatGPT:** Best for quick, conversational insights. No desktop setup required.
+  * **Claude Desktop:** Ideal for users who prefer Anthropic’s AI and desktop workflows.
+  * **Other MCP clients:** Use these for specific integrations or advanced setups.
+
+
+
+Choose the client that aligns with your workflow and preferences.
+
+Troubleshooting ›
+
+  * **Authentication failed:** generate a fresh Word + PIN and try again.
+  * **No data visible:** ensure the app has health permissions and stays open.
+  * **MCP server not found:** confirm the MCP server/package is installed or the Claude bundle is enabled; restart the client.
+  * **Connection lost:** check network connectivity and restart the session.
+
+
+
+Disclaimers ›
+
+VytalLink does not provide medical advice, diagnosis, or treatment. For medical questions, consult a qualified professional.
+
+What is the difference between ChatGPT and MCP clients? ›
+
+ChatGPT is ideal for quick, conversational insights without any desktop setup. MCP clients, like Claude Desktop or VS Code, are designed for advanced workflows and professional use cases.
+
+What happens if I close the app during a session? ›
+
+If you close the app, the connection to your AI assistant is paused, and no new data will be relayed. To resume, simply reopen the app and restart the session.
+
+Can I use VytalLink offline? ›
+
+No, VytalLink requires an active internet connection to securely relay your health data to your AI assistant.
+
+What data does VytalLink access from my phone? ›
+
+VytalLink accesses only the health metrics you approve, such as sleep, workouts, steps, and heart rate. You have full control over what data is shared during each session.
+
+How is my privacy protected? ›
+
+Your privacy is our priority. VytalLink uses encryption to secure your data and operates as a stateless relay, meaning no data is stored. You control what is shared and can disconnect at any time.
+
+Why don’t I see all my data, like sleep details? ›
+
+  1. Your wearable might not sync all data to Apple Health (iOS) or Health Connect (Android). Ensure your device is properly connected and syncing.
+  2. Some wearables only share limited data. For example, they might log a sleep session but not provide detailed sleep stages (like deep or REM sleep).
+
+
+
+Can I use VytalLink with multiple AI clients simultaneously? ›
+
+Yes, you can connect to multiple AI clients simultaneously. However, we recommend maintaining a single active connection for simplicity and to avoid potential data conflicts.
+
+---
+
+# mcp-setup
+
+# MCP Setup Guide
+
+Connect vytalLink to any MCP client in a few minutes
+
+Claude Desktop
+
+Cursor
+
+VS Code
+
+__ Any MCP Client
+
+## Prerequisites
+
+What you need before setting up MCP
+
+__
+
+### vytalLink Mobile App
+
+Download and set up the vytalLink mobile app to generate your connection Word + PIN.
+
+[ __App Store](https://apps.apple.com/app/id6752308627) [ __Google Play](https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink)
+
+__
+
+### Node.js & npm
+
+Required to install and run the vytalLink MCP server package.
+
+[ __Download Node.js](https://nodejs.org/)
+
+__
+
+### MCP Client
+
+Any MCP-compatible client like Claude Desktop, Cursor, or VS Code with MCP support.
+
+[ Claude Desktop ](https://claude.ai/download)
+
+## Setup Instructions
+
+Choose your MCP client and follow the setup guide
+
+Claude Desktop  Cursor  VS Code  __Other MCP Clients
+
+1
+
+### Install the MCP Server
+
+__ Looking for the one-click experience? Use the [Claude Desktop bundle guide](/claude-bundle-setup.html) instead.
+
+Install the vytalLink MCP server package globally using npm:
+
+Terminal __
+    
+    
+    npm install -g @xmartlabs/vytallink-mcp-server
+
+2
+
+### Configure Claude Desktop
+
+Add vytalLink to your Claude Desktop configuration file:
+
+#### Configuration file location:
+
+macOS Windows Linux
+
+`~/Library/Application Support/Claude/claude_desktop_config.json`
+
+`%APPDATA%\Claude\claude_desktop_config.json`
+
+`~/.config/claude/claude_desktop_config.json`
+
+claude_desktop_config.json __
+    
+    
+    {
+      "mcpServers": {
+        "vytalLink": {
+          "command": "npx",
+          "args": [
+            "@xmartlabs/vytallink-mcp-server"
+          ]
+        }
+      }
+    }
+
+3
+
+### Restart Claude Desktop
+
+Close and restart Claude Desktop to load the new MCP server configuration.
+
+4
+
+### Connect Your Health Data
+
+Use the Word + PIN from your vytalLink mobile app to authenticate:
+
+**You:** Connect to my health data using Word HEALTH7 and PIN sunset42 
+
+**Claude:** I've successfully connected to your health data! I can now help you analyze your fitness metrics, sleep patterns, and wellness trends. 
+
+1
+
+### Install the MCP Server
+
+Install the vytalLink MCP server package:
+
+Terminal __
+    
+    
+    npm install -g @xmartlabs/vytallink-mcp-server
+
+2
+
+### Configure Cursor
+
+Add vytalLink to your Cursor MCP configuration:
+
+Cursor MCP Configuration __
+    
+    
+    {
+      "mcpServers": {
+        "vytalLink": {
+          "command": "npx",
+          "args": [
+            "@xmartlabs/vytallink-mcp-server"
+          ]
+        }
+      }
+    }
+
+3
+
+### Enable MCP in Cursor
+
+Make sure MCP is enabled in Cursor settings and restart the application.
+
+__ Check Cursor's documentation for the latest MCP setup instructions
+
+1
+
+### Install MCP Extension
+
+Install an MCP-compatible extension in VS Code (availability may vary).
+
+__ MCP support in VS Code is evolving. Check the VS Code marketplace for MCP extensions.
+
+2
+
+### Install the MCP Server
+
+Terminal __
+    
+    
+    npm install -g @xmartlabs/vytallink-mcp-server
+
+3
+
+### Configure MCP Server
+
+Create or edit the MCP configuration file in your VS Code user directory:
+
+macOS Windows Linux
+
+`~/Library/Application Support/Code/User/mcp.json`
+
+`%APPDATA%\Code\User\mcp.json`
+
+`~/.config/Code/User/mcp.json`
+
+mcp.json __
+    
+    
+    {
+      "servers": {
+        "vytalLink": {
+          "command": "npx",
+          "args": ["@xmartlabs/vytallink-mcp-server"]
+        }
+      }
+    }
+
+4
+
+### Restart VS Code
+
+Close and restart VS Code to load the new MCP server configuration.
+
+1
+
+### Install the MCP Server
+
+Terminal __
+    
+    
+    npm install -g @xmartlabs/vytallink-mcp-server
+
+2
+
+### Generic MCP Configuration
+
+Use this configuration template for any MCP-compatible client:
+
+MCP Configuration Template __
+    
+    
+    {
+      "mcpServers": {
+        "vytalLink": {
+          "command": "npx",
+          "args": [
+            "@xmartlabs/vytallink-mcp-server"
+          ]
+        }
+      }
+    }
+
+3
+
+### Client-Specific Setup
+
+Follow your MCP client's documentation to:
+
+  * Add the server configuration
+  * Enable MCP functionality
+  * Restart the application
+
+
+
+## Troubleshooting
+
+Common issues and solutions
+
+### __MCP server not found
+
+Verify that @xmartlabs/vytallink-mcp-server is installed globally and npx is available in your PATH.
+
+### __Authentication failed
+
+Check that you're using the correct Word + PIN from your vytalLink mobile app. Credentials expire after some time.
+
+### __No health data
+
+Ensure your mobile app has permission to access health data and is actively syncing with your device's health platform.
+
+### Need More Help?
+
+If you're still having issues, check our documentation or reach out for support:
+
+[ __GitHub Repository](https://github.com/xmartlabs/vytalLink) [ __Contact Support](https://xmartlabs.com)

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -1,0 +1,25 @@
+# VytalLink
+
+> Privacy-first platform connecting wearable health data (Apple Health, Google Health Connect) to AI assistants via MCP (Model Context Protocol). Your data stays on your phone.
+
+VytalLink is a mobile app that acts as a local MCP server, exposing health metrics from Apple HealthKit and Google Health Connect to AI tools like Claude Desktop and ChatGPT. Users share access via a Word + PIN credential system — no cloud upload of health data.
+
+## Product
+
+- [Home](https://vytallink.xmartlabs.com/): Overview, features, and download links for iOS and Android
+- [About](https://vytallink.xmartlabs.com/about.md): Mission, values, and the Xmartlabs team behind VytalLink
+- [FAQ](https://vytallink.xmartlabs.com/faq.md): Common questions about the app and integrations
+
+## Setup Guides
+
+- [MCP Advanced Setup](https://vytallink.xmartlabs.com/mcp-setup.md): Connect any MCP-compatible AI agent to VytalLink (Claude Desktop, Cursor, VS Code, and more)
+- [ChatGPT Setup](https://vytallink.xmartlabs.com/chatgpt-setup.md): Use the VytalLink custom GPT in ChatGPT
+- [Claude Desktop Bundle Setup](https://vytallink.xmartlabs.com/claude-bundle-setup.md): Connect Claude Desktop using the pre-built one-click bundle
+
+## Developers
+
+- [Developer Guide](https://vytallink.xmartlabs.com/developers.md): Build health data agents in 5 minutes — TypeScript and Python examples, MCP tools reference, authentication flow
+
+## Full content
+
+- [llms-full.txt](https://vytallink.xmartlabs.com/llms-full.txt): All pages concatenated for single-file consumption

--- a/landing/public/mcp-setup.md
+++ b/landing/public/mcp-setup.md
@@ -2,254 +2,222 @@
 
 Connect vytalLink to any MCP client in a few minutes
 
-Claude Desktop
-
-Cursor
-
-VS Code
-
-__ Any MCP Client
+Supported clients: Claude Desktop, Cursor, VS Code, and other MCP-compatible clients.
 
 ## Prerequisites
 
 What you need before setting up MCP
 
-__
-
 ### vytalLink Mobile App
 
 Download and set up the vytalLink mobile app to generate your connection Word + PIN.
 
-[ __App Store](https://apps.apple.com/app/id6752308627) [ __Google Play](https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink)
-
-__
+- [App Store](https://apps.apple.com/app/id6752308627)
+- [Google Play](https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink)
 
 ### Node.js & npm
 
 Required to install and run the vytalLink MCP server package.
 
-[ __Download Node.js](https://nodejs.org/)
-
-__
+- [Download Node.js](https://nodejs.org/)
 
 ### MCP Client
 
 Any MCP-compatible client like Claude Desktop, Cursor, or VS Code with MCP support.
 
-[ Claude Desktop ](https://claude.ai/download)
+- [Claude Desktop](https://claude.ai/download)
 
 ## Setup Instructions
 
 Choose your MCP client and follow the setup guide
 
-Claude Desktop  Cursor  VS Code  __Other MCP Clients
+## Claude Desktop
 
-1
+### Step 1: Install the MCP Server
 
-### Install the MCP Server
-
-__ Looking for the one-click experience? Use the [Claude Desktop bundle guide](/claude-bundle-setup.html) instead.
+> Looking for the one-click experience? Use the [Claude Desktop bundle guide](/claude-bundle-setup.html) instead.
 
 Install the vytalLink MCP server package globally using npm:
 
-Terminal __
-    
-    
-    npm install -g @xmartlabs/vytallink-mcp-server
+#### Terminal
 
-2
+```
+npm install -g @xmartlabs/vytallink-mcp-server
+```
 
-### Configure Claude Desktop
+### Step 2: Configure Claude Desktop
 
 Add vytalLink to your Claude Desktop configuration file:
 
-#### Configuration file location:
+#### Configuration File Locations
 
-macOS Windows Linux
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux:** `~/.config/claude/claude_desktop_config.json`
 
-`~/Library/Application Support/Claude/claude_desktop_config.json`
+#### claude_desktop_config.json
 
-`%APPDATA%\Claude\claude_desktop_config.json`
-
-`~/.config/claude/claude_desktop_config.json`
-
-claude_desktop_config.json __
-    
-    
-    {
-      "mcpServers": {
-        "vytalLink": {
-          "command": "npx",
-          "args": [
-            "@xmartlabs/vytallink-mcp-server"
-          ]
-        }
-      }
+```json
+{
+  "mcpServers": {
+    "vytalLink": {
+      "command": "npx",
+      "args": [
+        "@xmartlabs/vytallink-mcp-server"
+      ]
     }
+  }
+}
+```
 
-3
-
-### Restart Claude Desktop
+### Step 3: Restart Claude Desktop
 
 Close and restart Claude Desktop to load the new MCP server configuration.
 
-4
-
-### Connect Your Health Data
+### Step 4: Connect Your Health Data
 
 Use the Word + PIN from your vytalLink mobile app to authenticate:
 
-**You:** Connect to my health data using Word HEALTH7 and PIN sunset42 
+#### Example Conversation
+- **You:** Connect to my health data using Word HEALTH7 and PIN sunset42
+- **Claude:** I've successfully connected to your health data! I can now help you analyze your fitness metrics, sleep patterns, and wellness trends.
 
-**Claude:** I've successfully connected to your health data! I can now help you analyze your fitness metrics, sleep patterns, and wellness trends. 
+## Cursor
 
-1
-
-### Install the MCP Server
+### Step 1: Install the MCP Server
 
 Install the vytalLink MCP server package:
 
-Terminal __
-    
-    
-    npm install -g @xmartlabs/vytallink-mcp-server
+#### Terminal
 
-2
+```
+npm install -g @xmartlabs/vytallink-mcp-server
+```
 
-### Configure Cursor
+### Step 2: Configure Cursor
 
 Add vytalLink to your Cursor MCP configuration:
 
-Cursor MCP Configuration __
-    
-    
-    {
-      "mcpServers": {
-        "vytalLink": {
-          "command": "npx",
-          "args": [
-            "@xmartlabs/vytallink-mcp-server"
-          ]
-        }
-      }
+#### Cursor MCP Configuration
+
+```json
+{
+  "mcpServers": {
+    "vytalLink": {
+      "command": "npx",
+      "args": [
+        "@xmartlabs/vytallink-mcp-server"
+      ]
     }
+  }
+}
+```
 
-3
-
-### Enable MCP in Cursor
+### Step 3: Enable MCP in Cursor
 
 Make sure MCP is enabled in Cursor settings and restart the application.
 
-__ Check Cursor's documentation for the latest MCP setup instructions
+> Check Cursor's documentation for the latest MCP setup instructions
 
-1
+## VS Code
 
-### Install MCP Extension
+### Step 1: Install MCP Extension
 
 Install an MCP-compatible extension in VS Code (availability may vary).
 
-__ MCP support in VS Code is evolving. Check the VS Code marketplace for MCP extensions.
+> MCP support in VS Code is evolving. Check the VS Code marketplace for MCP extensions.
 
-2
+### Step 2: Install the MCP Server
 
-### Install the MCP Server
+#### Terminal
 
-Terminal __
-    
-    
-    npm install -g @xmartlabs/vytallink-mcp-server
+```
+npm install -g @xmartlabs/vytallink-mcp-server
+```
 
-3
-
-### Configure MCP Server
+### Step 3: Configure MCP Server
 
 Create or edit the MCP configuration file in your VS Code user directory:
 
-macOS Windows Linux
+#### Configuration File Locations
 
-`~/Library/Application Support/Code/User/mcp.json`
+- **macOS:** `~/Library/Application Support/Code/User/mcp.json`
+- **Windows:** `%APPDATA%\Code\User\mcp.json`
+- **Linux:** `~/.config/Code/User/mcp.json`
 
-`%APPDATA%\Code\User\mcp.json`
+#### mcp.json
 
-`~/.config/Code/User/mcp.json`
-
-mcp.json __
-    
-    
-    {
-      "servers": {
-        "vytalLink": {
-          "command": "npx",
-          "args": ["@xmartlabs/vytallink-mcp-server"]
-        }
-      }
+```json
+{
+  "servers": {
+    "vytalLink": {
+      "command": "npx",
+      "args": ["@xmartlabs/vytallink-mcp-server"]
     }
+  }
+}
+```
 
-4
-
-### Restart VS Code
+### Step 4: Restart VS Code
 
 Close and restart VS Code to load the new MCP server configuration.
 
-1
+## Other MCP Clients
 
-### Install the MCP Server
+### Step 1: Install the MCP Server
 
-Terminal __
-    
-    
-    npm install -g @xmartlabs/vytallink-mcp-server
+#### Terminal
 
-2
+```
+npm install -g @xmartlabs/vytallink-mcp-server
+```
 
-### Generic MCP Configuration
+### Step 2: Generic MCP Configuration
 
 Use this configuration template for any MCP-compatible client:
 
-MCP Configuration Template __
-    
-    
-    {
-      "mcpServers": {
-        "vytalLink": {
-          "command": "npx",
-          "args": [
-            "@xmartlabs/vytallink-mcp-server"
-          ]
-        }
-      }
+#### MCP Configuration Template
+
+```json
+{
+  "mcpServers": {
+    "vytalLink": {
+      "command": "npx",
+      "args": [
+        "@xmartlabs/vytallink-mcp-server"
+      ]
     }
+  }
+}
+```
 
-3
-
-### Client-Specific Setup
+### Step 3: Client-Specific Setup
 
 Follow your MCP client's documentation to:
 
-  * Add the server configuration
-  * Enable MCP functionality
-  * Restart the application
-
-
+- Add the server configuration
+- Enable MCP functionality
+- Restart the application
 
 ## Troubleshooting
 
 Common issues and solutions
 
-### __MCP server not found
+### MCP server not found
 
 Verify that @xmartlabs/vytallink-mcp-server is installed globally and npx is available in your PATH.
 
-### __Authentication failed
+### Authentication failed
 
 Check that you're using the correct Word + PIN from your vytalLink mobile app. Credentials expire after some time.
 
-### __No health data
+### No health data
 
 Ensure your mobile app has permission to access health data and is actively syncing with your device's health platform.
 
-### Need More Help?
+## Need More Help?
 
 If you're still having issues, check our documentation or reach out for support:
 
-[ __GitHub Repository](https://github.com/xmartlabs/vytalLink) [ __Contact Support](https://xmartlabs.com)
+- [GitHub Repository](https://github.com/xmartlabs/vytalLink)
+- [Contact Support](https://xmartlabs.com)

--- a/landing/public/mcp-setup.md
+++ b/landing/public/mcp-setup.md
@@ -1,0 +1,255 @@
+# MCP Setup Guide
+
+Connect vytalLink to any MCP client in a few minutes
+
+Claude Desktop
+
+Cursor
+
+VS Code
+
+__ Any MCP Client
+
+## Prerequisites
+
+What you need before setting up MCP
+
+__
+
+### vytalLink Mobile App
+
+Download and set up the vytalLink mobile app to generate your connection Word + PIN.
+
+[ __App Store](https://apps.apple.com/app/id6752308627) [ __Google Play](https://play.google.com/store/apps/details?id=com.xmartlabs.vytallink)
+
+__
+
+### Node.js & npm
+
+Required to install and run the vytalLink MCP server package.
+
+[ __Download Node.js](https://nodejs.org/)
+
+__
+
+### MCP Client
+
+Any MCP-compatible client like Claude Desktop, Cursor, or VS Code with MCP support.
+
+[ Claude Desktop ](https://claude.ai/download)
+
+## Setup Instructions
+
+Choose your MCP client and follow the setup guide
+
+Claude Desktop  Cursor  VS Code  __Other MCP Clients
+
+1
+
+### Install the MCP Server
+
+__ Looking for the one-click experience? Use the [Claude Desktop bundle guide](/claude-bundle-setup.html) instead.
+
+Install the vytalLink MCP server package globally using npm:
+
+Terminal __
+    
+    
+    npm install -g @xmartlabs/vytallink-mcp-server
+
+2
+
+### Configure Claude Desktop
+
+Add vytalLink to your Claude Desktop configuration file:
+
+#### Configuration file location:
+
+macOS Windows Linux
+
+`~/Library/Application Support/Claude/claude_desktop_config.json`
+
+`%APPDATA%\Claude\claude_desktop_config.json`
+
+`~/.config/claude/claude_desktop_config.json`
+
+claude_desktop_config.json __
+    
+    
+    {
+      "mcpServers": {
+        "vytalLink": {
+          "command": "npx",
+          "args": [
+            "@xmartlabs/vytallink-mcp-server"
+          ]
+        }
+      }
+    }
+
+3
+
+### Restart Claude Desktop
+
+Close and restart Claude Desktop to load the new MCP server configuration.
+
+4
+
+### Connect Your Health Data
+
+Use the Word + PIN from your vytalLink mobile app to authenticate:
+
+**You:** Connect to my health data using Word HEALTH7 and PIN sunset42 
+
+**Claude:** I've successfully connected to your health data! I can now help you analyze your fitness metrics, sleep patterns, and wellness trends. 
+
+1
+
+### Install the MCP Server
+
+Install the vytalLink MCP server package:
+
+Terminal __
+    
+    
+    npm install -g @xmartlabs/vytallink-mcp-server
+
+2
+
+### Configure Cursor
+
+Add vytalLink to your Cursor MCP configuration:
+
+Cursor MCP Configuration __
+    
+    
+    {
+      "mcpServers": {
+        "vytalLink": {
+          "command": "npx",
+          "args": [
+            "@xmartlabs/vytallink-mcp-server"
+          ]
+        }
+      }
+    }
+
+3
+
+### Enable MCP in Cursor
+
+Make sure MCP is enabled in Cursor settings and restart the application.
+
+__ Check Cursor's documentation for the latest MCP setup instructions
+
+1
+
+### Install MCP Extension
+
+Install an MCP-compatible extension in VS Code (availability may vary).
+
+__ MCP support in VS Code is evolving. Check the VS Code marketplace for MCP extensions.
+
+2
+
+### Install the MCP Server
+
+Terminal __
+    
+    
+    npm install -g @xmartlabs/vytallink-mcp-server
+
+3
+
+### Configure MCP Server
+
+Create or edit the MCP configuration file in your VS Code user directory:
+
+macOS Windows Linux
+
+`~/Library/Application Support/Code/User/mcp.json`
+
+`%APPDATA%\Code\User\mcp.json`
+
+`~/.config/Code/User/mcp.json`
+
+mcp.json __
+    
+    
+    {
+      "servers": {
+        "vytalLink": {
+          "command": "npx",
+          "args": ["@xmartlabs/vytallink-mcp-server"]
+        }
+      }
+    }
+
+4
+
+### Restart VS Code
+
+Close and restart VS Code to load the new MCP server configuration.
+
+1
+
+### Install the MCP Server
+
+Terminal __
+    
+    
+    npm install -g @xmartlabs/vytallink-mcp-server
+
+2
+
+### Generic MCP Configuration
+
+Use this configuration template for any MCP-compatible client:
+
+MCP Configuration Template __
+    
+    
+    {
+      "mcpServers": {
+        "vytalLink": {
+          "command": "npx",
+          "args": [
+            "@xmartlabs/vytallink-mcp-server"
+          ]
+        }
+      }
+    }
+
+3
+
+### Client-Specific Setup
+
+Follow your MCP client's documentation to:
+
+  * Add the server configuration
+  * Enable MCP functionality
+  * Restart the application
+
+
+
+## Troubleshooting
+
+Common issues and solutions
+
+### __MCP server not found
+
+Verify that @xmartlabs/vytallink-mcp-server is installed globally and npx is available in your PATH.
+
+### __Authentication failed
+
+Check that you're using the correct Word + PIN from your vytalLink mobile app. Credentials expire after some time.
+
+### __No health data
+
+Ensure your mobile app has permission to access health data and is actively syncing with your device's health platform.
+
+### Need More Help?
+
+If you're still having issues, check our documentation or reach out for support:
+
+[ __GitHub Repository](https://github.com/xmartlabs/vytalLink) [ __Contact Support](https://xmartlabs.com)

--- a/landing/scripts/build-llms.sh
+++ b/landing/scripts/build-llms.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Install dependencies into the same interpreter used to run the generator.
+# Homebrew-managed Python may require these flags for user installs.
+if ! python3 -c "import html2text, bs4" 2>/dev/null; then
+  echo "Installing dependencies..."
+  python3 -m pip install --user --break-system-packages html2text beautifulsoup4
+fi
+
+python3 "$ROOT_DIR/scripts/generate_md.py"
+echo "Done. Run 'firebase serve --only hosting --port 5000' to verify."

--- a/landing/scripts/generate_md.py
+++ b/landing/scripts/generate_md.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Converts HTML pages to Markdown for LLM consumption (llms.txt standard).
+
+Usage:
+    pip install html2text beautifulsoup4
+    python3 scripts/generate_md.py
+"""
+import html2text
+from bs4 import BeautifulSoup
+from pathlib import Path
+
+# Pages excluded from LLM content: UI-only, legal boilerplate, or redirect pages
+EXCLUDE = {"index", "terms", "privacy", "demo", "app", "contact"}
+
+PUBLIC = Path(__file__).parent.parent / "public"
+
+
+def html_to_md(html_path: Path) -> str:
+    soup = BeautifulSoup(html_path.read_text(encoding="utf-8"), "html.parser")
+
+    # Remove nav and footer — keep only content sections
+    for tag in soup.find_all(["nav", "footer"]):
+        tag.decompose()
+
+    # Remove script and style tags
+    for tag in soup.find_all(["script", "style"]):
+        tag.decompose()
+
+    body = soup.find("body") or soup
+    h = html2text.HTML2Text()
+    h.ignore_links = False
+    h.ignore_images = True
+    h.body_width = 0
+    h.ignore_emphasis = False
+    return h.handle(str(body)).strip()
+
+
+def main() -> None:
+    all_md: list[str] = []
+    pages = sorted(f.stem for f in PUBLIC.glob("*.html") if f.stem not in EXCLUDE)
+
+    for page in pages:
+        html_file = PUBLIC / f"{page}.html"
+
+        md = html_to_md(html_file)
+        out = PUBLIC / f"{page}.md"
+        out.write_text(md, encoding="utf-8")
+        all_md.append(f"# {page}\n\n{md}")
+        print(f"Generated {out.name}")
+
+    full_path = PUBLIC / "llms-full.txt"
+    full_path.write_text("\n\n---\n\n".join(all_md), encoding="utf-8")
+    print(f"Generated {full_path.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/landing/scripts/generate_md.py
+++ b/landing/scripts/generate_md.py
@@ -1,38 +1,597 @@
 #!/usr/bin/env python3
-"""Converts HTML pages to Markdown for LLM consumption (llms.txt standard).
+"""Generate LLM-friendly Markdown from landing pages."""
 
-Usage:
-    pip install html2text beautifulsoup4
-    python3 scripts/generate_md.py
-"""
-import html2text
-from bs4 import BeautifulSoup
+from __future__ import annotations
+
+import re
 from pathlib import Path
 
-# Pages excluded from LLM content: UI-only, legal boilerplate, or redirect pages
-EXCLUDE = {"index", "terms", "privacy", "demo", "app", "contact"}
+import html2text
+from bs4 import BeautifulSoup, NavigableString, Tag
 
+
+EXCLUDE = {"index", "terms", "privacy", "demo", "app", "contact"}
 PUBLIC = Path(__file__).parent.parent / "public"
+APP_DOWNLOAD_URL = "https://vytallink.xmartlabs.com/app"
+
+
+def new_converter() -> html2text.HTML2Text:
+    converter = html2text.HTML2Text()
+    converter.ignore_links = False
+    converter.ignore_images = True
+    converter.body_width = 0
+    converter.ignore_emphasis = False
+    return converter
+
+
+def clean_text(value: str) -> str:
+    return " ".join(value.replace("\xa0", " ").split()).replace(" ›", "").strip()
+
+
+def normalize_markdown(markdown: str) -> str:
+    lines = [line.rstrip() for line in markdown.splitlines()]
+    cleaned: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "__":
+            continue
+        if re.fullmatch(r"\[\s*(.*?)\s*\]", stripped):
+            line = re.sub(r"\[\s*(.*?)\s*\]", lambda match: f"[{match.group(1).strip()}]", line)
+        cleaned.append(line)
+
+    markdown = "\n".join(cleaned)
+    markdown = re.sub(r"\n{3,}", "\n\n", markdown)
+    return markdown.strip()
+
+
+def join_blocks(blocks: list[str]) -> str:
+    return normalize_markdown("\n\n".join(block.strip() for block in blocks if block and block.strip()))
+
+
+def clone_tag(tag: Tag) -> Tag:
+    return BeautifulSoup(str(tag), "html.parser").find()  # type: ignore[return-value]
+
+
+def text_from(node: Tag | None) -> str:
+    if node is None:
+        return ""
+    return clean_text(node.get_text(" ", strip=True))
+
+
+def strip_fragment_noise(fragment: Tag) -> Tag:
+    for selector in [".copy-btn", ".brand-mark", ".arrow"]:
+        for node in fragment.select(selector):
+            node.decompose()
+
+    for node in fragment.find_all(["i", "img", "button"]):
+        node.decompose()
+
+    return fragment
+
+
+def fragment_to_markdown(node: Tag) -> str:
+    fragment = strip_fragment_noise(clone_tag(node))
+    return normalize_markdown(new_converter().handle(str(fragment)).strip())
+
+
+def inner_markdown(node: Tag) -> str:
+    fragment = BeautifulSoup("".join(str(child) for child in node.contents), "html.parser")
+    root = fragment.find() or fragment
+    if isinstance(root, Tag):
+        root = strip_fragment_noise(root)
+    return normalize_markdown(new_converter().handle(str(fragment)).strip())
+
+
+def render_list(list_tag: Tag) -> str:
+    ordered = list_tag.name == "ol"
+    lines: list[str] = []
+
+    for index, item in enumerate(list_tag.find_all("li", recursive=False), start=1):
+        clone = clone_tag(item)
+        for nested in clone.find_all(["ul", "ol"]):
+            nested.decompose()
+
+        prefix = f"{index}. " if ordered else "- "
+        content = inner_markdown(clone)
+        lines.append(f"{prefix}{content}")
+
+    return "\n".join(lines)
+
+
+def list_links(anchors: list[Tag]) -> str:
+    lines: list[str] = []
+    for anchor in anchors:
+        label = text_from(anchor)
+        href = anchor.get("href", "").strip()
+        if not href or href == "#":
+            if "download-app-btn" in anchor.get("class", []):
+                href = APP_DOWNLOAD_URL
+            else:
+                continue
+        lines.append(f"- [{label}]({href})")
+    return "\n".join(lines)
+
+
+def code_language(code_tag: Tag) -> str:
+    for class_name in code_tag.get("class", []):
+        if class_name.startswith("language-"):
+            return class_name.removeprefix("language-")
+    return ""
+
+
+def render_code_block(code_block: Tag, heading: str | None = None, level: int = 4) -> str:
+    code_tag = code_block.find("code")
+    if code_tag is None:
+        return ""
+
+    heading_text = heading or text_from(code_block.select_one(".code-header span"))
+    language = code_language(code_tag)
+    code = code_tag.get_text("\n").strip("\n")
+
+    blocks = [f"{'#' * level} {heading_text}" if heading_text else ""]
+    blocks.append(f"```{language}\n{code}\n```".strip())
+    return join_blocks(blocks)
+
+
+def render_note(tag: Tag) -> str:
+    note = fragment_to_markdown(tag)
+    return "\n".join("> " + line if line else ">" for line in note.splitlines())
+
+
+def render_paths(container: Tag) -> str:
+    lines: list[str] = []
+    for path in container.select(".os-path"):
+        path_id = path.get("id", "").lower()
+        if "windows" in path_id:
+            label = "Windows"
+        elif "linux" in path_id:
+            label = "Linux"
+        else:
+            label = "macOS"
+
+        code = text_from(path.find("code"))
+        if code:
+            lines.append(f"- **{label}:** `{code}`")
+
+    if not lines:
+        return ""
+
+    return join_blocks(["#### Configuration File Locations", "\n".join(lines)])
+
+
+def render_auth_example(container: Tag) -> str:
+    lines = ["#### Example Conversation"]
+    for message in container.select(".chat-message"):
+        speaker = text_from(message.find("strong")).rstrip(":")
+        text = clean_text(message.get_text(" ", strip=True))
+        if speaker:
+            text = text.removeprefix(f"{speaker}:").strip()
+            lines.append(f"- **{speaker}:** {text}")
+        elif text:
+            lines.append(f"- {text}")
+    return "\n".join(lines)
+
+
+def render_prerequisites(section: Tag) -> str:
+    blocks = ["## Prerequisites"]
+    intro = section.select_one(".section-header p")
+    if intro:
+        blocks.append(text_from(intro))
+
+    for card in section.select(".prereq-card"):
+        title = text_from(card.find("h3"))
+        parts = [f"### {title}", *[fragment_to_markdown(p) for p in card.find_all("p", recursive=False)]]
+        links = list_links(card.select(".prereq-links a"))
+        if links:
+            parts.append(links)
+        blocks.append(join_blocks(parts))
+
+    return join_blocks(blocks)
+
+
+def render_support_links(section: Tag) -> str:
+    title = text_from(section.find("h3"))
+    intro = fragment_to_markdown(section.find("p")) if section.find("p") else ""
+    links = list_links(section.select("a"))
+    return join_blocks([f"## {title}", intro, links])
+
+
+def render_steps(steps: list[Tag], extra_renderer: callable | None = None) -> list[str]:
+    blocks: list[str] = []
+    for step in steps:
+        number = text_from(step.select_one(".step-number"))
+        title = text_from(step.find("h3"))
+        parts = [f"### Step {number}: {title}"]
+        content = step.select_one(".step-content")
+        if content is None:
+            blocks.append(join_blocks(parts))
+            continue
+
+        for child in content.children:
+            if isinstance(child, NavigableString):
+                continue
+            if child.name == "h3":
+                continue
+
+            classes = set(child.get("class", []))
+            if child.name == "p":
+                parts.append(fragment_to_markdown(child))
+            elif "code-block" in classes:
+                parts.append(render_code_block(child))
+            elif classes & {"cursor-note", "vscode-note"}:
+                parts.append(render_note(child))
+            elif classes & {"config-location", "config-paths"}:
+                parts.append(render_paths(child))
+            elif "auth-example" in classes:
+                parts.append(render_auth_example(child))
+            elif extra_renderer is not None:
+                rendered = extra_renderer(child)
+                if rendered:
+                    parts.append(rendered)
+            elif child.name in {"ul", "ol"}:
+                parts.append(render_list(child))
+
+        blocks.append(join_blocks(parts))
+
+    return blocks
+
+
+def render_about(soup: BeautifulSoup) -> str:
+    hero = soup.select_one(".about-hero")
+    blocks = [
+        f"# {text_from(hero.find('h1'))}",
+        text_from(hero.select_one(".hero-subtitle")),
+    ]
+
+    for section in soup.select(".about-section"):
+        title = section.select_one(".content-text h2") or section.select_one(".section-title")
+        if title is None:
+            continue
+
+        section_blocks = [f"## {text_from(title)}"]
+        for paragraph in section.select(".content-text > p"):
+            section_blocks.append(fragment_to_markdown(paragraph))
+
+        if section.select(".value-card"):
+            for card in section.select(".value-card"):
+                section_blocks.append(join_blocks([
+                    f"### {text_from(card.find('h3'))}",
+                    fragment_to_markdown(card.find("p")),
+                ]))
+
+        cta_links = list_links(section.select(".cta-buttons a"))
+        if cta_links:
+            section_blocks.append(cta_links)
+
+        blocks.append(join_blocks(section_blocks))
+
+    return join_blocks(blocks)
+
+
+def render_chatgpt_setup(soup: BeautifulSoup) -> str:
+    hero = soup.select_one(".setup-header")
+    blocks = [
+        f"# {text_from(hero.find('h1'))}",
+        fragment_to_markdown(hero.find("p")),
+        "_Most Popular Integration_",
+    ]
+
+    what_is = soup.select_one(".what-is-section")
+    if what_is:
+        section = [f"## {text_from(what_is.find('h2'))}"]
+        intro = what_is.select_one(".what-is-text > p")
+        if intro:
+            section.append(fragment_to_markdown(intro))
+        features = [text_from(feature.select_one("span")) for feature in what_is.select(".gpt-feature")]
+        section.append("\n".join(f"- {feature}" for feature in features if feature))
+        example_user = text_from(what_is.select_one(".chat-message.user span"))
+        example_assistant = text_from(what_is.select_one(".chat-message.assistant span"))
+        section.append(join_blocks([
+            "### Example Conversation",
+            f"- **You:** {example_user}",
+            f"- **Assistant:** {example_assistant}",
+        ]))
+        blocks.append(join_blocks(section))
+
+    steps_section = soup.select_one(".setup-instructions")
+    if steps_section:
+        section = [f"## {text_from(steps_section.find('h2'))}", text_from(steps_section.select_one(".section-header p"))]
+
+        def render_chatgpt_step_extra(child: Tag) -> str:
+            classes = set(child.get("class", []))
+            if "gpt-access-options" in classes:
+                option_blocks: list[str] = []
+                for option in child.select(".gpt-option"):
+                    option_blocks.append(join_blocks([
+                        f"#### {text_from(option.find('h4'))}",
+                        fragment_to_markdown(option.find("p")),
+                        list_links(option.select("a")),
+                    ]))
+                return join_blocks(option_blocks)
+            return ""
+
+        section.extend(render_steps(steps_section.select(".setup-steps > .step"), render_chatgpt_step_extra))
+        blocks.append(join_blocks(section))
+
+    examples = soup.select_one(".examples-section")
+    if examples:
+        questions = [text_from(node) for node in examples.select(".question-bubble")]
+        blocks.append(join_blocks([
+            f"## {text_from(examples.find('h2'))}",
+            text_from(examples.select_one(".section-header p")),
+            "\n".join(f"- {question}" for question in questions if question),
+        ]))
+
+    cta = soup.select_one(".cta-section")
+    if cta:
+        blocks.append(join_blocks([
+            f"## {text_from(cta.find('h2'))}",
+            fragment_to_markdown(cta.find("p")),
+            f"- [Download the VytalLink app]({APP_DOWNLOAD_URL})",
+            list_links([link for link in cta.select(".cta-buttons a") if link.get("href") != "#"]),
+        ]))
+
+    return join_blocks(blocks)
+
+
+def render_claude_bundle_setup(soup: BeautifulSoup) -> str:
+    hero = soup.select_one(".setup-header")
+    blocks = [
+        f"# {text_from(hero.find('h1'))}",
+        fragment_to_markdown(hero.find("p")),
+    ]
+
+    prereqs = soup.select_one(".prerequisites")
+    if prereqs:
+        blocks.append(render_prerequisites(prereqs))
+
+    setup = soup.select_one(".setup-instructions")
+    if setup:
+        section = [f"## {text_from(setup.find('h2'))}", text_from(setup.select_one(".section-header p"))]
+
+        def render_bundle_step_extra(child: Tag) -> str:
+            classes = set(child.get("class", []))
+            if "cursor-note" in classes or "bundle-alternative" in classes:
+                return render_note(child)
+            return ""
+
+        section.extend(render_steps(setup.select(".setup-steps > .step"), render_bundle_step_extra))
+        alternative = setup.select_one(".bundle-alternative")
+        if alternative:
+            section.append(render_note(alternative))
+        blocks.append(join_blocks(section))
+
+    troubleshooting = soup.select_one(".troubleshooting")
+    if troubleshooting:
+        section = [f"## {text_from(troubleshooting.find('h2'))}", text_from(troubleshooting.select_one(".section-header p"))]
+        for item in troubleshooting.select(".faq-item"):
+            section.append(join_blocks([
+                f"### {text_from(item.find('h3'))}",
+                fragment_to_markdown(item.find("p")),
+            ]))
+        blocks.append(join_blocks(section))
+
+    return join_blocks(blocks)
+
+
+def render_mcp_setup(soup: BeautifulSoup) -> str:
+    hero = soup.select_one(".setup-header")
+    blocks = [
+        f"# {text_from(hero.find('h1'))}",
+        fragment_to_markdown(hero.find("p")),
+        "Supported clients: Claude Desktop, Cursor, VS Code, and other MCP-compatible clients.",
+    ]
+
+    prereqs = soup.select_one(".prerequisites")
+    if prereqs:
+        blocks.append(render_prerequisites(prereqs))
+
+    setup = soup.select_one(".setup-instructions")
+    if setup:
+        section = [f"## {text_from(setup.find('h2'))}", text_from(setup.select_one(".section-header p"))]
+
+        tabs = {
+            "claude-content": "Claude Desktop",
+            "cursor-content": "Cursor",
+            "vscode-content": "VS Code",
+            "other-content": "Other MCP Clients",
+        }
+
+        for panel_id, title in tabs.items():
+            panel = setup.select_one(f"#{panel_id}")
+            if panel is None:
+                continue
+
+            panel_parts = [f"## {title}"]
+            panel_parts.extend(render_steps(panel.select(".setup-steps > .step")))
+            section.append(join_blocks(panel_parts))
+
+        blocks.append(join_blocks(section))
+
+    troubleshooting = soup.select_one(".troubleshooting")
+    if troubleshooting:
+        section = [f"## {text_from(troubleshooting.find('h2'))}", text_from(troubleshooting.select_one(".section-header p"))]
+        for item in troubleshooting.select(".faq-item"):
+            section.append(join_blocks([
+                f"### {text_from(item.find('h3'))}",
+                fragment_to_markdown(item.find("p")),
+            ]))
+
+        support = troubleshooting.select_one(".support-section")
+        if support:
+            section.append(render_support_links(support))
+        blocks.append(join_blocks(section))
+
+    return join_blocks(blocks)
+
+
+def render_developers(soup: BeautifulSoup) -> str:
+    hero = soup.select_one(".setup-header")
+    blocks = [
+        f"# {text_from(hero.find('h1'))}",
+        fragment_to_markdown(hero.find("p")),
+    ]
+
+    overview = soup.select_one(".dev-overview")
+    if overview:
+        lines = []
+        for card in overview.select(".dev-overview-card"):
+            lines.append(f"- **{text_from(card.find('h3'))}:** {fragment_to_markdown(card.find('p'))}")
+        blocks.append(join_blocks(["## Why VytalLink", "\n".join(lines)]))
+
+    how_it_works = soup.select_one(".dev-how-it-works")
+    if how_it_works:
+        section = [
+            f"## {text_from(how_it_works.select_one('.section-header h2'))}",
+            text_from(how_it_works.select_one(".section-header p")),
+            "### How It Works",
+            render_list(how_it_works.select_one(".dev-flow-steps-list")),
+        ]
+
+        for step in how_it_works.select(".setup-steps > .step"):
+            number = text_from(step.select_one(".step-number"))
+            title = text_from(step.find("h3"))
+            parts = [f"### Step {number}: {title}"]
+            content = step.select_one(".step-content")
+            if content is None:
+                continue
+
+            lead = content.find("p", recursive=False)
+            if lead:
+                parts.append(fragment_to_markdown(lead))
+
+            if title == "Integrate the VytalLink server":
+                callout = content.select_one(".dev-template-callout")
+                if callout:
+                    parts.append(join_blocks([
+                        "#### Recommended: Health Kit Template",
+                        fragment_to_markdown(callout.find("p")),
+                        list_links(callout.select("a")),
+                    ]))
+
+                for panel in content.select(".dev-step-code .client-content"):
+                    heading = "TypeScript Example" if panel.get("data-client-panel") == "typescript" else "Python Example"
+                    code_block = panel.select_one(".code-block")
+                    if code_block:
+                        parts.append(render_code_block(code_block, heading))
+
+            elif title == "Link the user":
+                deeplink = content.select_one(".dev-deeplink-widget")
+                if deeplink:
+                    parts.append(join_blocks([
+                        "#### Share Link",
+                        f"- [Download App]({APP_DOWNLOAD_URL})",
+                        f"- Direct link: `{text_from(deeplink.select_one('#deeplink-example'))}`",
+                    ]))
+
+                auth_intro = content.find_all("p", recursive=False)
+                if len(auth_intro) > 1:
+                    parts.append(fragment_to_markdown(auth_intro[1]))
+
+                for panel in content.select(".client-content"):
+                    heading = "TypeScript Example" if panel.get("data-client-panel") == "typescript" else "Python Example"
+                    code_block = panel.select_one(".code-block")
+                    if code_block:
+                        parts.append(render_code_block(code_block, heading))
+
+            elif title == "Start querying data":
+                for panel in content.select(".client-content"):
+                    heading = "TypeScript Example" if panel.get("data-client-panel") == "typescript" else "Python Example"
+                    code_block = panel.select_one(".code-block")
+                    if code_block:
+                        parts.append(render_code_block(code_block, heading))
+
+            section.append(join_blocks(parts))
+
+        blocks.append(join_blocks(section))
+
+    notes = soup.select_one(".dev-notes")
+    if notes:
+        lines = []
+        for card in notes.select(".dev-note-card"):
+            badge = text_from(card.select_one(".dev-note-badge"))
+            title = text_from(card.find("h3"))
+            description = fragment_to_markdown(card.find("p"))
+            lines.append(f"- **{badge} - {title}:** {description}")
+        blocks.append(join_blocks([
+            f"## {text_from(notes.find('h2'))}",
+            text_from(notes.select_one(".section-header p")),
+            "\n".join(lines),
+        ]))
+
+    tools = soup.select_one(".dev-tools")
+    if tools:
+        lines = []
+        for card in tools.select(".dev-tool-card"):
+            lines.append(f"- `{text_from(card.find('h3'))}`: {fragment_to_markdown(card.find('p'))}")
+        reference_link = list_links(tools.select(".dev-swagger-cta a"))
+        blocks.append(join_blocks([
+            f"## {text_from(tools.find('h2'))}",
+            text_from(tools.select_one(".section-header p")),
+            "\n".join(lines),
+            reference_link,
+        ]))
+
+    return join_blocks(blocks)
+
+
+def render_faq(soup: BeautifulSoup) -> str:
+    hero = soup.select_one(".faq-hero")
+    blocks = [
+        f"# {text_from(hero.find('h1'))}",
+        text_from(hero.select_one(".hero-subtitle")),
+    ]
+
+    for item in soup.select(".faq-list > details"):
+        question = text_from(item.find("summary"))
+        answer = item.select_one(".faq-answer")
+        if answer is None:
+            continue
+
+        answer_blocks = [f"## {question}"]
+        for child in answer.children:
+            if isinstance(child, NavigableString):
+                continue
+            if child.name == "p":
+                answer_blocks.append(fragment_to_markdown(child))
+            elif child.name in {"ul", "ol"}:
+                answer_blocks.append(render_list(child))
+        blocks.append(join_blocks(answer_blocks))
+
+    return join_blocks(blocks)
+
+
+def render_generic(soup: BeautifulSoup) -> str:
+    main = soup.find("main") or soup.find("body") or soup
+    return fragment_to_markdown(main)
+
+
+RENDERERS = {
+    "about": render_about,
+    "chatgpt-setup": render_chatgpt_setup,
+    "claude-bundle-setup": render_claude_bundle_setup,
+    "developers": render_developers,
+    "faq": render_faq,
+    "mcp-setup": render_mcp_setup,
+}
 
 
 def html_to_md(html_path: Path) -> str:
     soup = BeautifulSoup(html_path.read_text(encoding="utf-8"), "html.parser")
 
-    # Remove nav and footer — keep only content sections
-    for tag in soup.find_all(["nav", "footer"]):
+    for tag in soup.find_all(["nav", "footer", "script", "style"]):
         tag.decompose()
 
-    # Remove script and style tags
-    for tag in soup.find_all(["script", "style"]):
-        tag.decompose()
+    renderer = RENDERERS.get(html_path.stem, render_generic)
+    return normalize_markdown(renderer(soup))
 
-    body = soup.find("body") or soup
-    h = html2text.HTML2Text()
-    h.ignore_links = False
-    h.ignore_images = True
-    h.body_width = 0
-    h.ignore_emphasis = False
-    return h.handle(str(body)).strip()
+
+def page_heading(markdown: str, fallback: str) -> str:
+    for line in markdown.splitlines():
+        if line.startswith("# "):
+            return line
+    return f"# {fallback}"
 
 
 def main() -> None:
@@ -41,15 +600,15 @@ def main() -> None:
 
     for page in pages:
         html_file = PUBLIC / f"{page}.html"
-
         md = html_to_md(html_file)
+
         out = PUBLIC / f"{page}.md"
-        out.write_text(md, encoding="utf-8")
-        all_md.append(f"# {page}\n\n{md}")
+        out.write_text(md + "\n", encoding="utf-8")
+        all_md.append(md)
         print(f"Generated {out.name}")
 
     full_path = PUBLIC / "llms-full.txt"
-    full_path.write_text("\n\n---\n\n".join(all_md), encoding="utf-8")
+    full_path.write_text("\n\n---\n\n".join(all_md) + "\n", encoding="utf-8")
     print(f"Generated {full_path.name}")
 
 

--- a/landing/scripts/test_generate_md.py
+++ b/landing/scripts/test_generate_md.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from generate_md import html_to_md
+
+
+PUBLIC = Path(__file__).resolve().parents[1] / "public"
+
+
+class GenerateMarkdownTests(unittest.TestCase):
+    def test_chatgpt_page_drops_mockup_artifacts(self) -> None:
+        markdown = html_to_md(PUBLIC / "chatgpt-setup.html")
+
+        self.assertIn("## What is vytalLink's Custom GPT?", markdown)
+        self.assertIn("- AI that understands health and fitness data", markdown)
+        self.assertNotIn("Word health", markdown)
+        self.assertNotIn("PIN 123456", markdown)
+        self.assertNotIn("__", markdown)
+
+    def test_mcp_page_expands_client_tabs_into_sections(self) -> None:
+        markdown = html_to_md(PUBLIC / "mcp-setup.html")
+
+        self.assertIn("## Claude Desktop", markdown)
+        self.assertIn("## Cursor", markdown)
+        self.assertIn("## VS Code", markdown)
+        self.assertIn("## Other MCP Clients", markdown)
+        self.assertNotIn("Claude Desktop  Cursor  VS Code", markdown)
+        self.assertNotIn("__", markdown)
+
+    def test_developers_page_keeps_labeled_code_examples(self) -> None:
+        markdown = html_to_md(PUBLIC / "developers.html")
+
+        self.assertIn("#### TypeScript Example", markdown)
+        self.assertIn("#### Python Example", markdown)
+        self.assertIn("```typescript", markdown)
+        self.assertIn("```python", markdown)
+        self.assertNotIn("Copy", markdown)
+        self.assertNotIn("__Developer's agent", markdown)
+
+    def test_faq_page_uses_conservative_privacy_wording(self) -> None:
+        markdown = html_to_md(PUBLIC / "faq.html")
+
+        self.assertIn("## Who receives my data during a session?", markdown)
+        self.assertNotIn("configured to not use your data for training", markdown)
+        self.assertNotIn("completely anonymous", markdown)
+        self.assertNotIn("no data is stored", markdown)
+        self.assertNotIn("›", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds llms.txt support to the Firebase landing site.
This publishes llms.txt, llms-full.txt, and generated Markdown mirrors for the main setup and product pages.
It also wires Markdown generation into Firebase predeploy and serves the new files with plain-text headers.
Validated with `cd landing && ./scripts/build-llms.sh`.
