### PR TITLE
feat: Add test mode docs and fix direct_login fields

### DIFF
--- a/landing/public/developers.html
+++ b/landing/public/developers.html
@@ -268,6 +268,16 @@ async with stdio_client(server_params) as (read, write):
 )</code></pre>
                             </div>
                         </div>
+
+                        <div class="dev-template-callout">
+                            <div class="dev-template-callout-icon">
+                                <i class="fas fa-vial"></i>
+                            </div>
+                            <div class="dev-template-callout-body">
+                                <strong>For development: Test without a phone</strong>
+                                <p>Use word <code style="background: rgba(99, 102, 241, 0.12); color: #4f46e5; padding: 2px 6px; border-radius: 4px; font-weight: 600;">testmode</code> and code <code style="background: rgba(99, 102, 241, 0.12); color: #4f46e5; padding: 2px 6px; border-radius: 4px; font-weight: 600;">999999</code> to get realistic synthetic data for all 16 health metrics. No app needed, works right away for development and demos.</p>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/landing/scripts/generate_md.py
+++ b/landing/scripts/generate_md.py
@@ -725,6 +725,43 @@ def generate_mcp_reference(base_url: str) -> str | None:
 
     blocks: list[str] = ["# MCP API Reference"]
 
+    # --- Authentication (direct_login) ---
+    blocks.append(join_blocks([
+        "## Authentication — direct_login",
+        (
+            "Call `direct_login` via `POST /mcp/call` to get a Bearer token. "
+            "No Authorization header needed for this call.\n\n"
+            "**Request — exact field names (common mistakes in bold):**\n"
+            "- `word` (string, required) — the connection keyword from the VytalLink app (e.g. `\"island\"`). "
+            "**Not** `connection_word`, `username`, or `user_word`.\n"
+            "- `code` (string, required) — the 6-digit PIN from the VytalLink app (e.g. `\"828930\"`). "
+            "**Not** `pin`, `password`, or `otp`.\n\n"
+            "```json\n"
+            "{\n"
+            '  "name": "direct_login",\n'
+            '  "arguments": { "word": "island", "code": "828930" }\n'
+            "}\n"
+            "```\n\n"
+            "**Response — token location:**\n"
+            "```json\n"
+            "{\n"
+            '  "content": [{ "type": "text", "text": "Authentication successful! ..." }],\n'
+            '  "structuredContent": {\n'
+            '    "success": true,\n'
+            '    "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",\n'
+            '    "token_type": "Bearer",\n'
+            '    "expires_in": 7200\n'
+            "  }\n"
+            "}\n"
+            "```\n"
+            "Read the token from `structuredContent.access_token`. **It is not in `content[0].text`** "
+            "(the text field contains it as prose, but parse `structuredContent` — never regex the text field).\n\n"
+            "Use the token in all subsequent calls: `Authorization: Bearer <access_token>`.\n\n"
+            "**On failure** (wrong word/code), the HTTP status is still 200 but `structuredContent.success` is `false` "
+            "and an `error` key is present at the top level. Always check `structuredContent.success` before reading the token."
+        ),
+    ]))
+
     # --- Response format (static text) ---
     blocks.append(join_blocks([
         "## Response format",
@@ -735,19 +772,6 @@ def generate_mcp_reference(base_url: str) -> str | None:
             "The shape of `structuredContent` depends on the tool:\n"
             "- `get_health_metrics` / `get_summary`: `{ healthData, count, success }`\n"
             "- `direct_login`: `{ success, access_token, token_type, expires_in, user_id, message }`\n\n"
-            "**direct_login response example:**\n"
-            "```json\n"
-            "{\n"
-            '  "content": [{ "type": "text", "text": "Authentication successful! You are now logged in." }],\n'
-            '  "structuredContent": {\n'
-            '    "success": true,\n'
-            '    "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",\n'
-            '    "token_type": "Bearer",\n'
-            '    "expires_in": 7200\n'
-            "  }\n"
-            "}\n"
-            "```\n"
-            "The token is always in `structuredContent.access_token`. It is not in `content[0].text`.\n\n"
             "**healthData record fields** (for `get_health_metrics` and `get_summary`):\n"
             "- `type` (string): metric type in the response — **may differ from the `value_type` you sent**. "
             "Example: request `value_type: \"SLEEP\"` returns records with `type: \"SLEEP_SESSION\"`. "


### PR DESCRIPTION
## Summary
- Document `direct_login` input fields explicitly in `llms-full.txt` so AI crawlers pick up the correct parameter names
- Add a "Test without a phone" callout to the developers page (Step 2: Link the user) with `testmode`/`999999` credentials for development and demos
