### PR TITLE
chore: bump version to 1.0.4+4

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -3,7 +3,7 @@ description: VitalLink mobile application.
 
 publish_to: "none"
 
-version: 1.0.3+3
+version: 1.0.4+4
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bumps app version from `1.0.3+3` to `1.0.4+4` in `mobile/pubspec.yaml`
