### PR TITLE
chore: post-release 1.0.4 cleanup

### DIFF
--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -134,7 +134,7 @@ PODS:
   - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - health (13.2.0):
+  - health (13.2.1):
     - Flutter
   - integration_test (0.0.1):
     - Flutter
@@ -273,7 +273,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 09f341dfa8527d1612a09cbfe809a242c0b737af
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  health: afa47eecde2e04d74ae99e485e8e4bd18bdf9d75
+  health: b2123f165ca25ea7faaa4a4b3e7b1b6405483b28
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   network_info_plus: 6613d9d7cdeb0e6f366ed4dbe4b3c51c52d567a9

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				4B9280BCDC8A498038857CD3 /* [CP] Embed Pods Frameworks */,
 				76F211248CF2C6836207D6CB /* [CP] Copy Pods Resources */,
-				16F2430F2E71F2CA009DBEBC /* ShellScript */,
+				16F2430F2E71F2CA009DBEBC /* Copy Google Service info */,
 				0A9CD0D01B9EA3B05B629640 /* FlutterFire: "flutterfire upload-crashlytics-symbols" */,
 			);
 			buildRules = (
@@ -260,7 +260,7 @@
 			shellPath = /bin/sh;
 			shellScript = "\n#!/bin/bash\nPATH=\"${PATH}:$FLUTTER_ROOT/bin:${PUB_CACHE}/bin:$HOME/.pub-cache/bin\"\n\nif [ -z \"$PODS_ROOT\" ] || [ ! -d \"$PODS_ROOT/FirebaseCrashlytics\" ]; then\n  # Cannot use \"BUILD_DIR%/Build/*\" as per Firebase documentation, it points to \"flutter-project/build/ios/*\" path which doesn't have run script\n  DERIVED_DATA_PATH=$(echo \"$BUILD_ROOT\" | sed -E 's|(.*DerivedData/[^/]+).*|\\1|')\n  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=\"${DERIVED_DATA_PATH}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\nelse\n  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=\"$PODS_ROOT/FirebaseCrashlytics/run\"\nfi\n\n# Command to upload symbols script used to upload symbols to Firebase server\nflutterfire upload-crashlytics-symbols --upload-symbols-script-path=\"$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT\" --platform=ios --apple-project-path=\"${SRCROOT}\" --env-platform-name=\"${PLATFORM_NAME}\" --env-configuration=\"${CONFIGURATION}\" --env-project-dir=\"${PROJECT_DIR}\" --env-built-products-dir=\"${BUILT_PRODUCTS_DIR}\" --env-dwarf-dsym-folder-path=\"${DWARF_DSYM_FOLDER_PATH}\" --env-dwarf-dsym-file-name=\"${DWARF_DSYM_FILE_NAME}\" --env-infoplist-path=\"${INFOPLIST_PATH}\" --default-config=default\n";
 		};
-		16F2430F2E71F2CA009DBEBC /* ShellScript */ = {
+		16F2430F2E71F2CA009DBEBC /* Copy Google Service info */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -269,6 +269,7 @@
 			);
 			inputPaths = (
 			);
+			name = "Copy Google Service info";
 			outputFileListPaths = (
 			);
 			outputPaths = (

--- a/scripts/setup_wt.sh
+++ b/scripts/setup_wt.sh
@@ -47,7 +47,7 @@ matches_default_credential_pattern() {
   case "$relative_path" in
     .env|.env.local|.env.production|.env.development|*.private.env|*.local.env|*.production.env|*.development.env|\
     *"/secrets/"*|*"/secrets"|*"/credentials/"*|*"/credentials"|\
-    *GoogleService-Info*.plist|*google-services*.json|*serviceAccount*.json|*credentials*.json|\
+    *firebase.json|*GoogleService-Info*.plist|*google-services*.json|*serviceAccount*.json|*credentials*.json|\
     *keys.properties|*upload_certificate.pem|*.jks|*.keystore|*.p8|*.pem|*.key)
       return 0
       ;;


### PR DESCRIPTION
Bump health pod from 13.2.0 to 13.2.1 and rename the Xcode "ShellScript" build phase to "Copy Google Service info" for clarity. Also adds firebase.json to the secrets ignore pattern in setup_wt.sh so worktree setups don't accidentally copy it.